### PR TITLE
Add support of nulled references as props of hooks

### DIFF
--- a/database/useList.ts
+++ b/database/useList.ts
@@ -139,7 +139,10 @@ export default (query: database.Query | null | undefined): ListHook => {
   useEffect(
     () => {
       const query: database.Query | null | undefined = ref.current;
-      if (!query) return;
+      if (!query) {
+        dispatch({ type: 'value' })
+        return;
+      }
       // This is here to indicate that all the data has been successfully received
       query.once(
         'value',

--- a/database/useList.ts
+++ b/database/useList.ts
@@ -109,7 +109,7 @@ const reducer = (state: ReducerState, action: ReducerAction): ReducerState => {
   }
 };
 
-export default (query: database.Query): ListHook => {
+export default (query: database.Query | null | undefined): ListHook => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const ref = useIsEqualRef(query, () => dispatch({ type: 'reset' }));
@@ -138,7 +138,8 @@ export default (query: database.Query): ListHook => {
 
   useEffect(
     () => {
-      const query: database.Query = ref.current;
+      const query: database.Query | null | undefined = ref.current;
+      if (!query) return;
       // This is here to indicate that all the data has been successfully received
       query.once(
         'value',

--- a/database/useListKeys.ts
+++ b/database/useListKeys.ts
@@ -7,12 +7,11 @@ export type ListKeysHook = {
   value: string[];
 };
 
-export default (query: database.Query): ListKeysHook => {
+export default (query: database.Query | null | undefined): ListKeysHook => {
   const { error, loading, value } = useList(query);
-  // @ts-ignore
   return {
     error,
     loading,
-    value: value.map(snapshot => snapshot.key),
+    value: value.map(snapshot => snapshot.key as string),
   };
 };

--- a/database/useListVals.ts
+++ b/database/useListVals.ts
@@ -8,7 +8,7 @@ export type ListValsHook<T> = {
 };
 
 export default <T>(
-  query: database.Query,
+  query: database.Query | null | undefined,
   keyField?: string
 ): ListValsHook<T> => {
   const { error, loading, value } = useList(query);

--- a/database/useObject.ts
+++ b/database/useObject.ts
@@ -17,7 +17,10 @@ export default (query: database.Query | null | undefined): ObjectHook => {
   useEffect(
     () => {
       const query = ref.current;
-      if (!query) return;
+      if (!query) {
+        setValue(null);
+        return;
+      }
 
       query.on('value', setValue, setError);
 

--- a/database/useObject.ts
+++ b/database/useObject.ts
@@ -8,7 +8,7 @@ export type ObjectHook = {
   value?: database.DataSnapshot;
 };
 
-export default (query: database.Query): ObjectHook => {
+export default (query: database.Query | null | undefined): ObjectHook => {
   const { error, loading, reset, setError, setValue, value } = useLoadingValue<
     database.DataSnapshot
   >();
@@ -17,6 +17,8 @@ export default (query: database.Query): ObjectHook => {
   useEffect(
     () => {
       const query = ref.current;
+      if (!query) return;
+
       query.on('value', setValue, setError);
 
       return () => {

--- a/database/useObjectVal.ts
+++ b/database/useObjectVal.ts
@@ -7,7 +7,7 @@ export type ObjectValHook<T> = {
   value?: T;
 };
 
-export default <T>(query: database.Query): ObjectValHook<T> => {
+export default <T>(query: database.Query | null | undefined): ObjectValHook<T> => {
   const { error, loading, value } = useObject(query);
   return {
     error,

--- a/firestore/useCollection.ts
+++ b/firestore/useCollection.ts
@@ -9,7 +9,7 @@ export type CollectionHook = {
 };
 
 export default (
-  query: firestore.Query,
+  query: firestore.Query | null | undefined,
   options?: firestore.SnapshotListenOptions
 ): CollectionHook => {
   const { error, loading, reset, setError, setValue, value } = useLoadingValue<
@@ -19,6 +19,7 @@ export default (
 
   useEffect(
     () => {
+      if (!ref.current) return;
       const listener = options
         ? ref.current.onSnapshot(options, setValue, setError)
         : ref.current.onSnapshot(setValue, setError);

--- a/firestore/useDocument.ts
+++ b/firestore/useDocument.ts
@@ -9,7 +9,7 @@ export type DocumentHook = {
 };
 
 export default (
-  docRef: firestore.DocumentReference,
+  docRef: firestore.DocumentReference | null | undefined,
   options?: firestore.SnapshotListenOptions
 ): DocumentHook => {
   const { error, loading, reset, setError, setValue, value } = useLoadingValue<
@@ -19,6 +19,7 @@ export default (
 
   useEffect(
     () => {
+      if (!ref.current) return;
       const listener = options
         ? ref.current.onSnapshot(options, setValue, setError)
         : ref.current.onSnapshot(setValue, setError);

--- a/storage/useDownloadURL.ts
+++ b/storage/useDownloadURL.ts
@@ -8,18 +8,20 @@ export type DownloadURLHook = {
   value?: string;
 };
 
-export default (storageRef: storage.Reference): DownloadURLHook => {
+export default (storageRef: storage.Reference | null | undefined): DownloadURLHook => {
   const { error, loading, reset, setError, setValue, value } = useLoadingValue<
     string
   >();
-  const ref = useComparatorRef(
-    storageRef,
-    (v1, v2) => v1.fullPath === v2.fullPath,
-    reset
-  );
+  function isEqual(v1: storage.Reference | null | undefined, v2: storage.Reference | null | undefined): boolean {
+    const bothNull: boolean = !v1 && !v2;
+    const equal: boolean = !!v1 && !!v2 && v1.fullPath === v2.fullPath;
+    return bothNull || equal;
+  }
+  const ref = useComparatorRef(storageRef, isEqual, reset);
 
   useEffect(
     () => {
+      if (!ref.current) return;
       ref.current
         .getDownloadURL()
         .then(setValue)

--- a/util/refHooks.ts
+++ b/util/refHooks.ts
@@ -5,10 +5,10 @@ type RefHook<T> = {
 };
 
 export const useComparatorRef = <T>(
-  value: T,
-  isEqual: (v1: T, v2: T) => boolean,
+  value: T | null | undefined,
+  isEqual: (v1: T | null | undefined, v2: T | null | undefined) => boolean,
   onChange?: () => void
-): RefHook<T> => {
+): RefHook<T | null | undefined> => {
   const ref = useRef(value);
   useEffect(() => {
     if (!isEqual(value, ref.current)) {
@@ -26,15 +26,20 @@ export interface HasIsEqual<T> {
 }
 
 export const useIsEqualRef = <T extends HasIsEqual<T>>(
-  value: T,
+  value: T | null | undefined,
   onChange?: () => void
-): RefHook<T> => {
-  return useComparatorRef(value, (v1, v2) => v1.isEqual(v2), onChange);
+): RefHook<T | null | undefined> => {
+  function isEqual(v1: T | null | undefined, v2: T | null | undefined): boolean {
+    const bothNull: boolean = !v1 && !v2;
+    const equal: boolean = !!v1 && !!v2 && v1.isEqual(v2);
+    return bothNull || equal;
+  }
+  return useComparatorRef(value, isEqual, onChange);
 };
 
 export const useIdentifyRef = <T>(
-  value: T,
+  value: T | null | undefined,
   onChange?: () => void
-): RefHook<T> => {
+): RefHook<T | null | undefined> => {
   return useComparatorRef(value, (v1, v2) => v1 === v2, onChange);
 };


### PR DESCRIPTION
Developing using these hooks, I've been in front of situations that references cannot be mounted at the first component execution. As explained on (https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level)[React docs], hooks cannot be called inside as an *if* statement.

To avoid this, we can pass an invalid reference to the firebase hooks. But, if you have implemented the strongest security rules, you will receive a permission denied error.

So, we need to pass references optionally to solve all of these problems.

I've already added support by this PR!

Example of usage in a container that fits authenticated or not state:
```typescript
export function useUsername() {
  const { user } = useAuthState(auth)
  const usernameRef = user
    ? db.child('profiles').child(user.uid).child('username')
    : undefined
  const { value: username, loading, error } = useDatabaseObject(usernameRef)
  return { username, loading, error }
}
```