### PR TITLE
Fix flow types for firestore

### DIFF
--- a/firestore/index.js.flow
+++ b/firestore/index.js.flow
@@ -10,12 +10,12 @@ import type {
 export type CollectionHook = {
   error?: Object,
   loading: boolean,
-  value?: firestore.QuerySnapshot,
+  value?: QuerySnapshot,
 };
 export type DocumentHook = {
   error?: Object,
   loading: boolean,
-  value?: firestore.DocumentSnapshot,
+  value?: DocumentSnapshot,
 };
 
 declare export function useCollection(


### PR DESCRIPTION
The flow type declarations for the firestore module import QuerySnapshot but then try to use it as firestore.QuerySnapshot.