### PR TITLE
Memoize hook return

### DIFF
--- a/auth/useAuthState.ts
+++ b/auth/useAuthState.ts
@@ -1,5 +1,5 @@
 import { auth, User } from 'firebase';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { LoadingHook, useLoadingValue } from '../util';
 
 export type AuthStateHook = LoadingHook<User, auth.Error>;
@@ -21,5 +21,9 @@ export default (auth: auth.Auth): AuthStateHook => {
     [auth]
   );
 
-  return [value, loading, error];
+  const resArray:AuthStateHook = [value, loading, error]
+  return useMemo<AuthStateHook>(
+    () => resArray,
+    resArray,
+  );
 };

--- a/database/useList.ts
+++ b/database/useList.ts
@@ -72,9 +72,13 @@ export const useList = (query?: database.Query | null): ListHook => {
 };
 
 export const useListKeys = (query?: database.Query | null): ListKeysHook => {
-  const [value, loading, error] = useList(query);
+  const [snapshots, loading, error] = useList(query);
+  const values = useMemo(
+    () => (snapshots ? snapshots.map(snapshot => snapshot.key as string) : undefined),
+    [snapshots]
+  );
   const resArray: ListKeysHook = [
-    value ? value.map(snapshot => snapshot.key as string) : undefined,
+    values,
     loading,
     error,
   ];

--- a/database/useList.ts
+++ b/database/useList.ts
@@ -64,16 +64,25 @@ export const useList = (query?: database.Query | null): ListHook => {
     };
   }, [ref.current]);
 
-  return [state.value.values, state.loading, state.error];
+  const resArray: ListHook = [state.value.values, state.loading, state.error];
+  return useMemo(
+    () => resArray,
+    resArray,
+  );
 };
 
 export const useListKeys = (query?: database.Query | null): ListKeysHook => {
   const [value, loading, error] = useList(query);
-  return [
+  const resArray: ListKeysHook = [
     value ? value.map(snapshot => snapshot.key as string) : undefined,
     loading,
     error,
   ];
+
+  return useMemo(
+    () => resArray,
+    resArray,
+  );
 };
 
 export const useListVals = <T>(
@@ -92,5 +101,10 @@ export const useListVals = <T>(
         : undefined,
     [snapshots, options && options.keyField]
   );
-  return [values, loading, error];
+
+  const resArray: ListValsHook<T> = [values, loading, error];
+  return useMemo(
+    () => resArray,
+    resArray,
+  );
 };

--- a/database/useList.ts
+++ b/database/useList.ts
@@ -75,7 +75,7 @@ export const useList = (query?: firebase.database.Query | null): ListHook => {
 };
 
 export const useListKeys = (
-  query?: database.Query | null
+  query?: firebase.database.Query | null
 ): ListKeysHook => {
   const [snapshots, loading, error] = useList(query);
   const values = useMemo(

--- a/database/useObject.ts
+++ b/database/useObject.ts
@@ -30,7 +30,11 @@ export const useObject = (query?: database.Query | null): ObjectHook => {
     [ref.current]
   );
 
-  return [value, loading, error];
+  const resArray: ObjectHook = [value, loading, error];
+  return useMemo(
+    () => resArray,
+    resArray,
+  );
 };
 
 export const useObjectVal = <T>(
@@ -47,5 +51,10 @@ export const useObjectVal = <T>(
         : undefined,
     [snapshot, options && options.keyField]
   );
-  return [value, loading, error];
+
+  const resArray: ObjectValHook<T> = [value, loading, error];
+  return useMemo(
+    () => resArray,
+    resArray,
+  );
 };

--- a/firestore/useCollection.ts
+++ b/firestore/useCollection.ts
@@ -40,7 +40,11 @@ export const useCollection = (
     [ref.current]
   );
 
-  return [value, loading, error];
+  const resArray: CollectionHook = [value, loading, error];
+  return useMemo(
+    () => resArray,
+    resArray,
+  );
 };
 
 export const useCollectionData = <T>(
@@ -64,5 +68,10 @@ export const useCollectionData = <T>(
         : undefined) as T[],
     [snapshot, idField]
   );
-  return [values, loading, error];
+
+  const resArray: CollectionDataHook<T> = [values, loading, error]
+  return useMemo(
+    () => resArray,
+    resArray,
+  );
 };

--- a/firestore/useCollection.ts
+++ b/firestore/useCollection.ts
@@ -58,15 +58,14 @@ export const useCollectionData = <T>(
   const snapshotListenOptions = options
     ? options.snapshotListenOptions
     : undefined;
-  const [snapshot, loading, error] = useCollection(query, {
+  const [snapshots, loading, error] = useCollection(query, {
     snapshotListenOptions,
   });
   const values = useMemo(
-    () =>
-      (snapshot
-        ? snapshot.docs.map(doc => snapshotToData(doc, idField))
-        : undefined) as T[],
-    [snapshot, idField]
+    () => (snapshots
+      ? snapshots.docs.map(doc => snapshotToData(doc, idField))
+      : undefined) as T[],
+    [snapshots, idField]
   );
 
   const resArray: CollectionDataHook<T> = [values, loading, error]

--- a/firestore/useCollectionOnce.ts
+++ b/firestore/useCollectionOnce.ts
@@ -1,5 +1,5 @@
 import { firestore } from 'firebase';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { snapshotToData } from './helpers';
 import { LoadingHook, useIsEqualRef, useLoadingValue } from '../util';
 
@@ -32,7 +32,11 @@ export const useCollectionOnce = (
     [ref.current]
   );
 
-  return [value, loading, error];
+  const resArray: CollectionOnceHook = [value, loading, error];
+  return useMemo(
+    () => resArray,
+    resArray,
+  );
 };
 
 export const useCollectionDataOnce = <T>(
@@ -45,11 +49,15 @@ export const useCollectionDataOnce = <T>(
   const idField = options ? options.idField : undefined;
   const getOptions = options ? options.getOptions : undefined;
   const [value, loading, error] = useCollectionOnce(query, { getOptions });
-  return [
+  const resArray: CollectionDataOnceHook<T> = [
     (value
       ? value.docs.map(doc => snapshotToData(doc, idField))
       : undefined) as T[],
     loading,
     error,
   ];
+  return useMemo(
+    () => resArray,
+    resArray,
+  );
 };

--- a/firestore/useCollectionOnce.ts
+++ b/firestore/useCollectionOnce.ts
@@ -48,11 +48,15 @@ export const useCollectionDataOnce = <T>(
 ): CollectionDataOnceHook<T> => {
   const idField = options ? options.idField : undefined;
   const getOptions = options ? options.getOptions : undefined;
-  const [value, loading, error] = useCollectionOnce(query, { getOptions });
-  const resArray: CollectionDataOnceHook<T> = [
-    (value
-      ? value.docs.map(doc => snapshotToData(doc, idField))
+  const [snapshots, loading, error] = useCollectionOnce(query, { getOptions });
+  const values = useMemo(
+    () => (snapshots
+      ? snapshots.docs.map(doc => snapshotToData(doc, idField))
       : undefined) as T[],
+    [snapshots, idField]
+  );
+  const resArray: CollectionDataOnceHook<T> = [
+    values,
     loading,
     error,
   ];

--- a/firestore/useDocument.ts
+++ b/firestore/useDocument.ts
@@ -40,7 +40,11 @@ export const useDocument = (
     [ref.current]
   );
 
-  return [value, loading, error];
+  const resArray: DocumentHook = [value, loading, error];
+  return useMemo(
+    () => resArray,
+    resArray,
+  );
 };
 
 export const useDocumentData = <T>(
@@ -61,5 +65,10 @@ export const useDocumentData = <T>(
     () => (snapshot ? snapshotToData(snapshot, idField) : undefined) as T,
     [snapshot, idField]
   );
-  return [value, loading, error];
+
+  const resArray: DocumentDataHook<T> = [value, loading, error];
+  return useMemo(
+    () => resArray,
+    resArray,
+  );
 };

--- a/firestore/useDocumentOnce.ts
+++ b/firestore/useDocumentOnce.ts
@@ -1,5 +1,5 @@
 import { firestore } from 'firebase';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { snapshotToData } from './helpers';
 import { LoadingHook, useIsEqualRef, useLoadingValue } from '../util';
 
@@ -32,7 +32,11 @@ export const useDocumentOnce = (
     [ref.current]
   );
 
-  return [value, loading, error];
+  const resArray: DocumentOnceHook = [value, loading, error]
+  return useMemo(
+    () => resArray,
+    resArray,
+  );
 };
 
 export const useDocumentDataOnce = <T>(
@@ -44,10 +48,15 @@ export const useDocumentDataOnce = <T>(
 ): DocumentDataOnceHook<T> => {
   const idField = options ? options.idField : undefined;
   const getOptions = options ? options.getOptions : undefined;
-  const [value, loading, error] = useDocumentOnce(docRef, { getOptions });
-  return [
-    (value ? snapshotToData(value, idField) : undefined) as T,
-    loading,
-    error,
-  ];
+  const [snapshot, loading, error] = useDocumentOnce(docRef, { getOptions });
+  const value = useMemo(
+    () => (snapshot ? snapshotToData(snapshot, idField) : undefined) as T,
+    [snapshot, idField]
+  );
+
+  const resArray: DocumentDataOnceHook<T> = [value, loading, error]
+  return useMemo(
+    () => resArray,
+    resArray,
+  );
 };

--- a/util/useLoadingValue.ts
+++ b/util/useLoadingValue.ts
@@ -1,4 +1,4 @@
-import { useReducer } from 'react';
+import { useMemo, useReducer } from 'react';
 
 export type LoadingValue<T, E> = {
   error?: E;
@@ -73,12 +73,21 @@ export default <T, E>(getDefaultValue?: () => T | null): LoadingValue<T, E> => {
     dispatch({ type: 'value', value });
   };
 
-  return {
-    error: state.error,
-    loading: state.loading,
-    reset,
-    setError,
-    setValue,
-    value: state.value,
-  };
+  return useMemo(
+    () => ({
+      error: state.error,
+      loading: state.loading,
+      reset,
+      setError,
+      setValue,
+      value: state.value,
+    }), [
+      state.error,
+      state.loading,
+      reset,
+      setError,
+      setValue,
+      state.value,
+    ]
+  );
 };


### PR DESCRIPTION
Avoid returning new arrays/objects when the components of said arrays/objects have not changed. This will help users avoid re-renders in their code.