### PR TITLE
Possibility to populate the firebase.firestore.QuerySnapshot.ref field

### DIFF
--- a/firestore/README.md
+++ b/firestore/README.md
@@ -118,6 +118,7 @@ The `useCollectionData` hook takes the following parameters:
 - `query`: (optional) `firebase.firestore.Query` for the data you would like to load
 - `options`: (optional) `Object` with the following parameters:
   - `idField`: (optional) name of the field that should be populated with the `firebase.firestore.QuerySnapshot.id` property.
+  - `refField`: (optional) name of the field that should be populated with the `firebase.firestore.QuerySnapshot.ref` property.
   - `snapshotListenOptions`: (optional) `firebase.firestore.SnapshotListenOptions` to customise how the collection is loaded
 
 Returns:
@@ -140,6 +141,7 @@ The `useCollectionDataOnce` hook takes the following parameters:
 - `options`: (optional) `Object` with the following parameters:
   - `getOptions`: (optional) `firebase.firestore.GetOptions` to customise how the collection is loaded
   - `idField`: (optional) name of the field that should be populated with the `firebase.firestore.QuerySnapshot.id` property.
+  - `refField`: (optional) name of the field that should be populated with the `firebase.firestore.QuerySnapshot.ref` property.
 
 Returns:
 
@@ -225,6 +227,7 @@ The `useDocumentData` hook takes the following parameters:
 - `reference`: (optional) `firebase.firestore.DocumentReference` for the data you would like to load
 - `options`: (optional) `Object` with the following parameters:
   - `idField`: (optional) name of the field that should be populated with the `firebase.firestore.DocumentSnapshot.id` property.
+  - `refField`: (optional) name of the field that should be populated with the `firebase.firestore.QuerySnapshot.ref` property.
   - `snapshotListenOptions`: (optional) `firebase.firestore.SnapshotListenOptions` to customise how the collection is loaded
 
 Returns:
@@ -247,6 +250,7 @@ The `useDocumentDataOnce` hook takes the following parameters:
 - `options`: (optional) `Object` with the following parameters:
   - `getOptions`: (optional) `firebase.firestore.GetOptions` to customise how the collection is loaded
   - `idField`: (optional) name of the field that should be populated with the `firebase.firestore.DocumentSnapshot.id` property.
+  - `refField`: (optional) name of the field that should be populated with the `firebase.firestore.QuerySnapshot.ref` property.
 
 Returns:
 

--- a/firestore/helpers/index.ts
+++ b/firestore/helpers/index.ts
@@ -2,7 +2,8 @@ import { firestore } from 'firebase';
 
 export const snapshotToData = (
   snapshot: firestore.DocumentSnapshot,
-  idField?: string
+  idField?: string,
+  refField?: string,
 ) => {
   if (!snapshot.exists) {
     return undefined;
@@ -11,5 +12,6 @@ export const snapshotToData = (
   return {
     ...snapshot.data(),
     ...(idField ? { [idField]: snapshot.id } : null),
+    ...(refField ? { [refField]: snapshot.ref } : null),
   };
 };

--- a/firestore/index.js.flow
+++ b/firestore/index.js.flow
@@ -31,6 +31,7 @@ declare export function useCollectionData<T>(
   query?: Query | null,
   options?: {
     idField?: string,
+    refField?: string,
     snapshotListenOptions?: SnapshotListenOptions,
   }
 ): CollectionDataHook<T>;
@@ -39,6 +40,7 @@ declare export function useCollectionDataOnce<T>(
   options?: {
     getOptions?: GetOptions,
     idField?: string,
+    refField?: string,
   }
 ): CollectionDataHook<T>;
 declare export function useDocument(
@@ -57,6 +59,7 @@ declare export function useDocumentData<T>(
   ref?: DocumentReference | null,
   options?: {
     idField?: string,
+    refField?: string,
     snapshotListenOptions?: SnapshotListenOptions,
   }
 ): DocumentDataHook<T>;
@@ -65,5 +68,6 @@ declare export function useDocumentDataOnce<T>(
   options?: {
     getOptions?: GetOptions,
     idField?: string,
+    refField?: string,
   }
 ): DocumentDataHook<T>;

--- a/firestore/useCollection.ts
+++ b/firestore/useCollection.ts
@@ -47,10 +47,12 @@ export const useCollectionData = <T>(
   query?: firestore.Query | null,
   options?: {
     idField?: string;
+    refField?: string;
     snapshotListenOptions?: firestore.SnapshotListenOptions;
   }
 ): CollectionDataHook<T> => {
   const idField = options ? options.idField : undefined;
+  const refField = options ? options.refField : undefined;
   const snapshotListenOptions = options
     ? options.snapshotListenOptions
     : undefined;
@@ -60,9 +62,9 @@ export const useCollectionData = <T>(
   const values = useMemo(
     () =>
       (snapshot
-        ? snapshot.docs.map(doc => snapshotToData(doc, idField))
+        ? snapshot.docs.map(doc => snapshotToData(doc, idField, refField))
         : undefined) as T[],
-    [snapshot, idField]
+    [snapshot, idField, refField]
   );
   return [values, loading, error];
 };

--- a/firestore/useCollectionOnce.ts
+++ b/firestore/useCollectionOnce.ts
@@ -40,14 +40,16 @@ export const useCollectionDataOnce = <T>(
   options?: {
     getOptions?: firestore.GetOptions;
     idField?: string;
+    refField?: string;
   }
 ): CollectionDataOnceHook<T> => {
   const idField = options ? options.idField : undefined;
+  const refField = options ? options.refField : undefined;
   const getOptions = options ? options.getOptions : undefined;
   const [value, loading, error] = useCollectionOnce(query, { getOptions });
   return [
     (value
-      ? value.docs.map(doc => snapshotToData(doc, idField))
+      ? value.docs.map(doc => snapshotToData(doc, idField, refField))
       : undefined) as T[],
     loading,
     error,

--- a/firestore/useDocument.ts
+++ b/firestore/useDocument.ts
@@ -47,10 +47,12 @@ export const useDocumentData = <T>(
   docRef?: firestore.DocumentReference | null,
   options?: {
     idField?: string;
+    refField?: string;
     snapshotListenOptions?: firestore.SnapshotListenOptions;
   }
 ): DocumentDataHook<T> => {
   const idField = options ? options.idField : undefined;
+  const refField = options ? options.refField : undefined;
   const snapshotListenOptions = options
     ? options.snapshotListenOptions
     : undefined;
@@ -58,8 +60,8 @@ export const useDocumentData = <T>(
     snapshotListenOptions,
   });
   const value = useMemo(
-    () => (snapshot ? snapshotToData(snapshot, idField) : undefined) as T,
-    [snapshot, idField]
+    () => (snapshot ? snapshotToData(snapshot, idField, refField) : undefined) as T,
+    [snapshot, idField, refField]
   );
   return [value, loading, error];
 };

--- a/firestore/useDocumentOnce.ts
+++ b/firestore/useDocumentOnce.ts
@@ -40,13 +40,15 @@ export const useDocumentDataOnce = <T>(
   options?: {
     getOptions?: firestore.GetOptions;
     idField?: string;
+    refField?: string;
   }
 ): DocumentDataOnceHook<T> => {
   const idField = options ? options.idField : undefined;
+  const refField = options ? options.refField : undefined;
   const getOptions = options ? options.getOptions : undefined;
   const [value, loading, error] = useDocumentOnce(docRef, { getOptions });
   return [
-    (value ? snapshotToData(value, idField) : undefined) as T,
+    (value ? snapshotToData(value, idField, refField) : undefined) as T,
     loading,
     error,
   ];


### PR DESCRIPTION
As suggested in #56, this PR add the functionality to specify a 'refField'. It works similar to the existing idField and populates the specified field with the value from firebase.firestore.QuerySnapshot.ref for easy access if required.

Closes #56 