### PR TITLE
Improve useList efficiency

### DIFF
--- a/database/helpers/useListReducer.ts
+++ b/database/helpers/useListReducer.ts
@@ -127,7 +127,7 @@ const listReducer = (
 
 const addChild = (
   currentState: KeyValueState,
-  snapshot: firebase.database.DataSnapshot,
+  snapshot: database.DataSnapshot,
   previousKey?: string | null
 ): KeyValueState => {
   if (!snapshot.key) {
@@ -157,7 +157,7 @@ const addChild = (
 
 const changeChild = (
   currentState: KeyValueState,
-  snapshot: firebase.database.DataSnapshot
+  snapshot: database.DataSnapshot
 ): KeyValueState => {
   if (!snapshot.key) {
     return currentState;
@@ -174,7 +174,7 @@ const changeChild = (
 
 const removeChild = (
   currentState: KeyValueState,
-  snapshot: firebase.database.DataSnapshot
+  snapshot: database.DataSnapshot
 ): KeyValueState => {
   if (!snapshot.key) {
     return currentState;
@@ -192,7 +192,7 @@ const removeChild = (
 
 const moveChild = (
   currentState: KeyValueState,
-  snapshot: firebase.database.DataSnapshot,
+  snapshot: database.DataSnapshot,
   previousKey?: string | null
 ): KeyValueState => {
   // Remove the child from it's previous location

--- a/database/helpers/useListReducer.ts
+++ b/database/helpers/useListReducer.ts
@@ -33,7 +33,7 @@ type RemoveAction = {
   snapshot: firebase.database.DataSnapshot | null;
 };
 type ResetAction = { type: 'reset' };
-type ValueAction = { type: 'value'; snapshots: database.DataSnapshot[] | null };
+type ValueAction = { type: 'value'; snapshots: firebase.database.DataSnapshot[] | null };
 type ReducerAction =
   | AddAction
   | ChangeAction
@@ -126,7 +126,7 @@ const listReducer = (
   }
 };
 
-const setValue = (snapshots: database.DataSnapshot[] | null): KeyValueState => {
+const setValue = (snapshots: firebase.database.DataSnapshot[] | null): KeyValueState => {
   if (!snapshots) {
     return {
       keys: [],
@@ -135,7 +135,7 @@ const setValue = (snapshots: database.DataSnapshot[] | null): KeyValueState => {
   }
 
   const keys: string[] = [];
-  const values: database.DataSnapshot[] = [];
+  const values: firebase.database.DataSnapshot[] = [];
   snapshots.forEach((snapshot) => {
     if (!snapshot.key) {
       return;
@@ -152,7 +152,7 @@ const setValue = (snapshots: database.DataSnapshot[] | null): KeyValueState => {
 
 const addChild = (
   currentState: KeyValueState,
-  snapshot: database.DataSnapshot,
+  snapshot: firebase.database.DataSnapshot,
   previousKey?: string | null
 ): KeyValueState => {
   if (!snapshot.key) {
@@ -182,7 +182,7 @@ const addChild = (
 
 const changeChild = (
   currentState: KeyValueState,
-  snapshot: database.DataSnapshot
+  snapshot: firebase.database.DataSnapshot
 ): KeyValueState => {
   if (!snapshot.key) {
     return currentState;
@@ -199,7 +199,7 @@ const changeChild = (
 
 const removeChild = (
   currentState: KeyValueState,
-  snapshot: database.DataSnapshot
+  snapshot: firebase.database.DataSnapshot
 ): KeyValueState => {
   if (!snapshot.key) {
     return currentState;
@@ -217,7 +217,7 @@ const removeChild = (
 
 const moveChild = (
   currentState: KeyValueState,
-  snapshot: database.DataSnapshot,
+  snapshot: firebase.database.DataSnapshot,
   previousKey?: string | null
 ): KeyValueState => {
   // Remove the child from it's previous location

--- a/database/helpers/useListReducer.ts
+++ b/database/helpers/useListReducer.ts
@@ -33,7 +33,7 @@ type RemoveAction = {
   snapshot: database.DataSnapshot | null;
 };
 type ResetAction = { type: 'reset' };
-type ValueAction = { type: 'value' };
+type ValueAction = { type: 'value'; snapshots: database.DataSnapshot[] | null };
 type ReducerAction =
   | AddAction
   | ChangeAction
@@ -110,6 +110,7 @@ const listReducer = (
         ...state,
         error: undefined,
         loading: false,
+        value: setValue(action.snapshots),
       };
     case 'empty':
       return {
@@ -123,6 +124,30 @@ const listReducer = (
     default:
       return state;
   }
+};
+
+const setValue = (snapshots: database.DataSnapshot[] | null): KeyValueState => {
+  if (!snapshots) {
+    return {
+      keys: [],
+      values: [],
+    };
+  }
+
+  const keys: string[] = [];
+  const values: database.DataSnapshot[] = [];
+  snapshots.forEach((snapshot) => {
+    if (!snapshot.key) {
+      return;
+    }
+    keys.push(snapshot.key);
+    values.push(snapshot);
+  });
+
+  return {
+    keys,
+    values,
+  };
 };
 
 const addChild = (

--- a/database/useList.ts
+++ b/database/useList.ts
@@ -109,13 +109,20 @@ export const useList = (query?: firebase.database.Query | null): ListHook => {
   return useMemo(() => resArray, resArray);
 };
 
-export const useListKeys = (query?: firebase.database.Query | null): ListKeysHook => {
-  const [value, loading, error] = useList(query);
-  return [
-    value ? value.map((snapshot) => snapshot.key as string) : undefined,
-    loading,
-    error,
-  ];
+export const useListKeys = (
+  query?: firebase.database.Query | null
+): ListKeysHook => {
+  const [snapshots, loading, error] = useList(query);
+  const values = useMemo(
+    () =>
+      snapshots
+        ? snapshots.map((snapshot) => snapshot.key as string)
+        : undefined,
+    [snapshots]
+  );
+  const resArray: ListKeysHook = [values, loading, error];
+
+  return useMemo(() => resArray, resArray);
 };
 
 export const useListVals = <T>(
@@ -132,10 +139,10 @@ export const useListVals = <T>(
     () =>
       snapshots
         ? snapshots.map((snapshot) =>
-            snapshotToData(snapshot, options ? options.keyField : undefined, refField)
+            snapshotToData(snapshot, keyField, refField)
           )
         : undefined,
-    [snapshots, options && options.keyField]
+    [snapshots, keyField, refField]
   );
 
   const resArray: ListValsHook<T> = [values, loading, error];

--- a/database/useList.ts
+++ b/database/useList.ts
@@ -11,58 +11,96 @@ export type ListValsHook<T> = LoadingHook<T[], FirebaseError>;
 export const useList = (query?: database.Query | null): ListHook => {
   const [state, dispatch] = useListReducer();
 
-  const ref = useIsEqualRef(query, () => dispatch({ type: 'reset' }));
-
-  const onChildAdded = (
-    snapshot: database.DataSnapshot | null,
-    previousKey?: string | null
-  ) => {
-    dispatch({ type: 'add', previousKey, snapshot });
-  };
-
-  const onChildChanged = (snapshot: database.DataSnapshot | null) => {
-    dispatch({ type: 'change', snapshot });
-  };
-
-  const onChildMoved = (
-    snapshot: database.DataSnapshot | null,
-    previousKey?: string | null
-  ) => {
-    dispatch({ type: 'move', previousKey, snapshot });
-  };
-
-  const onChildRemoved = (snapshot: database.DataSnapshot | null) => {
-    dispatch({ type: 'remove', snapshot });
-  };
-
-  const onError = (error: FirebaseError) => {
-    dispatch({ type: 'error', error });
-  };
-
-  const onValue = () => {
-    dispatch({ type: 'value' });
-  };
+  const queryRef = useIsEqualRef(query, () => dispatch({ type: 'reset' }));
 
   useEffect(() => {
-    const query: database.Query | null | undefined = ref.current;
-    if (!query) {
+    const ref: database.Query | null | undefined = queryRef.current;
+    if (!ref) {
       dispatch({ type: 'empty' });
       return;
     }
-    // This is here to indicate that all the data has been successfully received
-    query.once('value', onValue, onError);
-    query.on('child_added', onChildAdded, onError);
-    query.on('child_changed', onChildChanged, onError);
-    query.on('child_moved', onChildMoved, onError);
-    query.on('child_removed', onChildRemoved, onError);
+
+    const onChildAdded = (
+      snapshot: database.DataSnapshot | null,
+      previousKey?: string | null
+    ) => {
+      dispatch({ type: 'add', previousKey, snapshot });
+    };
+
+    const onChildChanged = (snapshot: database.DataSnapshot | null) => {
+      dispatch({ type: 'change', snapshot });
+    };
+
+    const onChildMoved = (
+      snapshot: database.DataSnapshot | null,
+      previousKey?: string | null
+    ) => {
+      dispatch({ type: 'move', previousKey, snapshot });
+    };
+
+    const onChildRemoved = (snapshot: database.DataSnapshot | null) => {
+      dispatch({ type: 'remove', snapshot });
+    };
+
+    const onError = (error: FirebaseError) => {
+      dispatch({ type: 'error', error });
+    };
+
+    const onValue = (snapshots: database.DataSnapshot[] | null) => {
+      dispatch({ type: 'value', snapshots });
+    };
+
+    let childAddedHandler: ReturnType<typeof ref.on> | undefined;
+    const children: database.DataSnapshot[] = [];
+    const onInitialLoad = (snapshot: database.DataSnapshot) => {
+      let childrenToProcess = Object.keys(snapshot.val()).length;
+
+      const onChildAddedWithoutInitialLoad = (
+        addedChild: database.DataSnapshot,
+        previousKey?: string
+      ) => {
+        // process the first batch of children all at once
+        if (childrenToProcess > 0) {
+          childrenToProcess--;
+          children.push(addedChild);
+
+          if (childrenToProcess === 0) {
+            onValue(children);
+          }
+
+          return;
+        }
+
+        onChildAdded(snapshot, previousKey);
+      };
+
+      childAddedHandler = ref.on(
+        'child_added',
+        onChildAddedWithoutInitialLoad,
+        onError
+      );
+    };
+
+    ref.once('value', onInitialLoad, onError);
+    const childChangedHandler = ref.on(
+      'child_changed',
+      onChildChanged,
+      onError
+    );
+    const childMovedHandler = ref.on('child_moved', onChildMoved, onError);
+    const childRemovedHandler = ref.on(
+      'child_removed',
+      onChildRemoved,
+      onError
+    );
 
     return () => {
-      query.off('child_added', onChildAdded);
-      query.off('child_changed', onChildChanged);
-      query.off('child_moved', onChildMoved);
-      query.off('child_removed', onChildRemoved);
+      ref.off('child_added', childAddedHandler);
+      ref.off('child_changed', childChangedHandler);
+      ref.off('child_moved', childMovedHandler);
+      ref.off('child_removed', childRemovedHandler);
     };
-  }, [ref.current]);
+  }, [dispatch, queryRef]);
 
   return [state.value.values, state.loading, state.error];
 };
@@ -70,7 +108,7 @@ export const useList = (query?: database.Query | null): ListHook => {
 export const useListKeys = (query?: database.Query | null): ListKeysHook => {
   const [value, loading, error] = useList(query);
   return [
-    value ? value.map(snapshot => snapshot.key as string) : undefined,
+    value ? value.map((snapshot) => snapshot.key as string) : undefined,
     loading,
     error,
   ];
@@ -86,7 +124,7 @@ export const useListVals = <T>(
   const values = useMemo(
     () =>
       snapshots
-        ? snapshots.map(snapshot =>
+        ? snapshots.map((snapshot) =>
             snapshotToData(snapshot, options ? options.keyField : undefined)
           )
         : undefined,

--- a/database/useList.ts
+++ b/database/useList.ts
@@ -15,9 +15,9 @@ export const useList = (query?: firebase.database.Query | null): ListHook => {
   const [state, dispatch] = useListReducer();
 
   const queryRef = useIsEqualRef(query, () => dispatch({ type: 'reset' }));
+  const ref: firebase.database.Query | null | undefined = queryRef.current;
 
   useEffect(() => {
-    const ref: firebase.database.Query | null | undefined = queryRef.current;
     if (!ref) {
       dispatch({ type: 'empty' });
       return;
@@ -30,7 +30,9 @@ export const useList = (query?: firebase.database.Query | null): ListHook => {
       dispatch({ type: 'add', previousKey, snapshot });
     };
 
-    const onChildChanged = (snapshot: firebase.database.DataSnapshot | null) => {
+    const onChildChanged = (
+      snapshot: firebase.database.DataSnapshot | null
+    ) => {
       dispatch({ type: 'change', snapshot });
     };
 
@@ -41,7 +43,9 @@ export const useList = (query?: firebase.database.Query | null): ListHook => {
       dispatch({ type: 'move', previousKey, snapshot });
     };
 
-    const onChildRemoved = (snapshot: firebase.database.DataSnapshot | null) => {
+    const onChildRemoved = (
+      snapshot: firebase.database.DataSnapshot | null
+    ) => {
       dispatch({ type: 'remove', snapshot });
     };
 
@@ -60,7 +64,7 @@ export const useList = (query?: firebase.database.Query | null): ListHook => {
 
       const onChildAddedWithoutInitialLoad = (
         addedChild: firebase.database.DataSnapshot,
-        previousKey?: string
+        previousKey?: string | null
       ) => {
         // process the first batch of children all at once
         if (childrenToProcess > 0) {
@@ -103,7 +107,7 @@ export const useList = (query?: firebase.database.Query | null): ListHook => {
       ref.off('child_moved', childMovedHandler);
       ref.off('child_removed', childRemovedHandler);
     };
-  }, [dispatch, queryRef]);
+  }, [dispatch, ref]);
 
   const resArray: ListHook = [state.value.values, state.loading, state.error];
   return useMemo(() => resArray, resArray);

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "2.8.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": ">= 16.8.0"
   },
   "typings": "index.d.ts"
 }


### PR DESCRIPTION
1. Use the `.once`’s `val()` to determine the number of children, then batch that many calls to the `child_added` handler into one `value` dispatch, resulting in one additional render instead of one progressively slower render per child.
2. Fix shadowing of `query` variable, rename to `ref` instead.
3. Fix the `ref.off` calls to pass the right function to unsubscribe.
4. Fix dependencies on `useEffect`.
5. Fix some type references.

Fixes #74