### PR TITLE
Add firebase v8 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "typescript": "2.8.1"
   },
   "peerDependencies": {
-    "react": ">= 16.8.0"
+    "react": ">= 16.8.0",
+    "firebase": ">= 8.0.0"
   },
   "typings": "index.d.ts"
 }


### PR DESCRIPTION
ref: #86

The firebase v8 support may make it difficult to use this hooks with earlier firebase versions.
It should be specified with the release of v3 major version.