### PR TITLE
fix: remove unnecessary import statement

### DIFF
--- a/auth/useSignInWithEmailAndPassword.ts
+++ b/auth/useSignInWithEmailAndPassword.ts
@@ -1,6 +1,5 @@
 import { useState, useMemo } from 'react';
 import firebase from 'firebase/app';
-import 'firebase/auth';
 import { EmailAndPasswordActionHook } from './types';
 
 export default (auth: firebase.auth.Auth): EmailAndPasswordActionHook => {


### PR DESCRIPTION
Close #121

`import 'firebase/auth';` is unnecessary and should be written in user code. It causes #121 issue.
(The current rollup settings doesn't consider `firebase/auth` as an external library, so `firebase/auth` is bundled in `react-firebase-hooks/auth`.)