### PR TITLE
Use DocumentReference type for Data ref attribute

### DIFF
--- a/firestore/types.ts
+++ b/firestore/types.ts
@@ -19,7 +19,9 @@ export type Data<
   T = firebase.firestore.DocumentData,
   IDField extends string = '',
   RefField extends string = ''
-> = T & Record<IDField, string> & Record<RefField, string>;
+> = T &
+  Record<IDField, string> &
+  Record<RefField, firebase.firestore.DocumentReference<T>>;
 
 export type CollectionHook<T = firebase.firestore.DocumentData> = LoadingHook<
   firebase.firestore.QuerySnapshot<T>,


### PR DESCRIPTION
This merge request corrects the type for the new `refField` attribute from `string` to `firebase.firestore.DocumentReference<T>`.

With this update, if `refField` was set to `ref`, one can call `item.ref.collection()...` etc, and get types as expected.