### PR TITLE
Export `IDOption` type

### DIFF
--- a/firestore/types.ts
+++ b/firestore/types.ts
@@ -1,7 +1,7 @@
 import firebase from 'firebase/app';
 import { LoadingHook } from '../util';
 
-type IDOptions<T> = {
+export type IDOptions<T> = {
   idField?: string;
   refField?: string;
   snapshotOptions?: firebase.firestore.SnapshotOptions;


### PR DESCRIPTION
Solution to issue #134 
This change will make the `IDOption` type included in the built types, which will allow `tsc` to understand the `DataOptions` and `OnceDataOptions` types.

This is my first Open Source contribution, so I hope I did it right :sweat_smile: 