### PR TITLE
fix: useList works wrong when a new child is added

### DIFF
--- a/database/useList.ts
+++ b/database/useList.ts
@@ -81,7 +81,7 @@ export const useList = (query?: firebase.database.Query | null): ListHook => {
             return;
           }
 
-          onChildAdded(snapshot, previousKey);
+          onChildAdded(addedChild, previousKey);
         };
 
         childAddedHandler = ref.on(


### PR DESCRIPTION
Hi and thanks for the awesome library!

Couple of days ago we faced the following issue: if a new child is added after `useList` hook was called, the list is updated as expected, but at the end it has a snapshot of the whole object in its initial state instead of a new child.

For example, let's assume that a new child `4` is added.

Expected behaviour:

```
[1, 2, 3] → [1, 2, 3, 4]
```

Actual behaviour:

```
[1, 2, 3] → [1, 2, 3, {a: 1, b: 2, c: 3}]
```

First we were searching for a bug in our code, but during debugging found that it's caused just by a small mistake in `onChildAdded` call.