### PR TITLE
Firebase 9 Support

### DIFF
--- a/auth/types.ts
+++ b/auth/types.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app';
+import { ActionCodeSettings, UserCredential, AuthError } from 'firebase/auth';
 
 export type AuthActionHook<T, E> = [
   (email: string, password: string) => void,
@@ -7,10 +7,10 @@ export type AuthActionHook<T, E> = [
   E | undefined
 ];
 export type CreateUserOptions = {
-  emailVerificationOptions?: firebase.auth.ActionCodeSettings;
+  emailVerificationOptions?: ActionCodeSettings;
   sendEmailVerification?: boolean;
 };
 export type EmailAndPasswordActionHook = AuthActionHook<
-  firebase.auth.UserCredential,
-  firebase.FirebaseError
+  UserCredential,
+  AuthError
 >;

--- a/auth/useAuthState.ts
+++ b/auth/useAuthState.ts
@@ -1,20 +1,20 @@
-import firebase from 'firebase/app';
+import { User, Auth, onAuthStateChanged } from 'firebase/auth';
 import { useEffect, useMemo } from 'react';
 import { LoadingHook, useLoadingValue } from '../util';
 
 export type AuthStateHook = LoadingHook<
-  firebase.User | null,
-  firebase.auth.Error
+  User | null,
+  Error
 >;
 
-export default (auth: firebase.auth.Auth): AuthStateHook => {
+export default (auth: Auth): AuthStateHook => {
   const { error, loading, setError, setValue, value } = useLoadingValue<
-    firebase.User | null,
-    firebase.auth.Error
+    User | null,
+    Error
   >(() => auth.currentUser);
 
   useEffect(() => {
-    const listener = auth.onAuthStateChanged(setValue, setError);
+    const listener = onAuthStateChanged(auth, setValue, setError);
 
     return () => {
       listener();

--- a/auth/useCreateUserWithEmailAndPassword.ts
+++ b/auth/useCreateUserWithEmailAndPassword.ts
@@ -1,16 +1,16 @@
 import { useState, useMemo } from 'react';
-import firebase from 'firebase/app';
 import { CreateUserOptions, EmailAndPasswordActionHook } from './types';
+import { Auth, UserCredential, createUserWithEmailAndPassword as _createUserWithEmailAndPassword, sendEmailVerification, AuthError } from 'firebase/auth';
 
 export default (
-  auth: firebase.auth.Auth,
+  auth: Auth,
   options?: CreateUserOptions
 ): EmailAndPasswordActionHook => {
-  const [error, setError] = useState<firebase.FirebaseError>();
+  const [error, setError] = useState<AuthError>();
   const [
     registeredUser,
     setRegisteredUser,
-  ] = useState<firebase.auth.UserCredential>();
+  ] = useState<UserCredential>();
   const [loading, setLoading] = useState<boolean>(false);
 
   const createUserWithEmailAndPassword = async (
@@ -19,9 +19,9 @@ export default (
   ) => {
     setLoading(true);
     try {
-      const user = await auth.createUserWithEmailAndPassword(email, password);
+      const user = await _createUserWithEmailAndPassword(auth, email, password);
       if (options && options.sendEmailVerification && user.user) {
-        await user.user.sendEmailVerification(options.emailVerificationOptions);
+        await sendEmailVerification(user.user, options.emailVerificationOptions);
       }
       setRegisteredUser(user);
       setLoading(false);

--- a/auth/useSignInWithEmailAndPassword.ts
+++ b/auth/useSignInWithEmailAndPassword.ts
@@ -1,13 +1,13 @@
 import { useState, useMemo } from 'react';
-import firebase from 'firebase/app';
+import { Auth, UserCredential, signInWithEmailAndPassword as _signInWithEmailAndPassword, AuthError } from 'firebase/auth';
 import { EmailAndPasswordActionHook } from './types';
 
-export default (auth: firebase.auth.Auth): EmailAndPasswordActionHook => {
-  const [error, setError] = useState<firebase.FirebaseError>();
+export default (auth: Auth): EmailAndPasswordActionHook => {
+  const [error, setError] = useState<AuthError>();
   const [
     loggedInUser,
     setLoggedInUser,
-  ] = useState<firebase.auth.UserCredential>();
+  ] = useState<UserCredential>();
   const [loading, setLoading] = useState<boolean>(false);
 
   const signInWithEmailAndPassword = async (
@@ -16,7 +16,7 @@ export default (auth: firebase.auth.Auth): EmailAndPasswordActionHook => {
   ) => {
     setLoading(true);
     try {
-      const user = await auth.signInWithEmailAndPassword(email, password);
+      const user = await _signInWithEmailAndPassword(auth, email, password);
       setLoggedInUser(user);
       setLoading(false);
     } catch (err) {

--- a/database/helpers/index.ts
+++ b/database/helpers/index.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app';
+import firebase from 'firebase/compat/app';
 
 export type ValOptions<T> = {
   keyField?: string;

--- a/database/helpers/useListReducer.ts
+++ b/database/helpers/useListReducer.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app';
+import firebase from 'firebase/compat/app';
 import { useReducer } from 'react';
 
 type KeyValueState = {

--- a/database/types.ts
+++ b/database/types.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app';
+import firebase from 'firebase/compat/app';
 import { LoadingHook } from '../util';
 
 export type Val<

--- a/database/useList.ts
+++ b/database/useList.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app';
+import firebase from 'firebase/compat/app';
 import { useEffect, useMemo } from 'react';
 import { snapshotToData, ValOptions } from './helpers';
 import useListReducer from './helpers/useListReducer';

--- a/database/useObject.ts
+++ b/database/useObject.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app';
+import firebase from 'firebase/compat/app';
 import { useEffect, useMemo } from 'react';
 import { snapshotToData, ValOptions } from './helpers';
 import { ObjectHook, ObjectValHook, Val } from './types';

--- a/firestore/helpers/index.ts
+++ b/firestore/helpers/index.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app';
+import firebase from 'firebase/compat/app';
 
 export const snapshotToData = <T = firebase.firestore.DocumentData>(
   snapshot: firebase.firestore.DocumentSnapshot,

--- a/firestore/types.ts
+++ b/firestore/types.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app';
+import firebase from 'firebase/compat/app';
 import { LoadingHook } from '../util';
 
 export type IDOptions<T> = {
@@ -25,20 +25,20 @@ export type Data<
 
 export type CollectionHook<T = firebase.firestore.DocumentData> = LoadingHook<
   firebase.firestore.QuerySnapshot<T>,
-  firebase.FirebaseError
+  firebase.firestore.FirestoreError
 >;
 export type CollectionDataHook<
   T = firebase.firestore.DocumentData,
   IDField extends string = '',
   RefField extends string = ''
-> = LoadingHook<Data<T, IDField, RefField>[], firebase.FirebaseError>;
+> = LoadingHook<Data<T, IDField, RefField>[], firebase.firestore.FirestoreError>;
 
 export type DocumentHook<T = firebase.firestore.DocumentData> = LoadingHook<
   firebase.firestore.DocumentSnapshot<T>,
-  firebase.FirebaseError
+  firebase.firestore.FirestoreError
 >;
 export type DocumentDataHook<
   T = firebase.firestore.DocumentData,
   IDField extends string = '',
   RefField extends string = ''
-> = LoadingHook<Data<T, IDField, RefField>, firebase.FirebaseError>;
+> = LoadingHook<Data<T, IDField, RefField>, firebase.firestore.FirestoreError>;

--- a/firestore/useCollection.ts
+++ b/firestore/useCollection.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app';
+import firebase from 'firebase/compat/app';
 import { useEffect, useMemo } from 'react';
 import { snapshotToData } from './helpers';
 import {
@@ -55,7 +55,7 @@ const useCollectionInternal = <T = firebase.firestore.DocumentData>(
 ) => {
   const { error, loading, reset, setError, setValue, value } = useLoadingValue<
     firebase.firestore.QuerySnapshot,
-    firebase.FirebaseError
+    firebase.firestore.FirestoreError
   >();
   const ref = useIsEqualRef(query, reset);
 

--- a/firestore/useDocument.ts
+++ b/firestore/useDocument.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app';
+import firebase from 'firebase/compat/app';
 import { useEffect, useMemo } from 'react';
 import { snapshotToData } from './helpers';
 import {
@@ -55,7 +55,7 @@ const useDocumentInternal = <T = firebase.firestore.DocumentData>(
 ): DocumentHook<T> => {
   const { error, loading, reset, setError, setValue, value } = useLoadingValue<
     firebase.firestore.DocumentSnapshot,
-    firebase.FirebaseError
+    firebase.firestore.FirestoreError
   >();
   const ref = useIsEqualRef(docRef, reset);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,23 +5,43 @@
   "requires": true,
   "dependencies": {
     "@firebase/analytics": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.2.tgz",
-      "integrity": "sha512-4Ceov+rPfOEPIdbjlpTim/wbcUUneIesHag4UOzvmFsRRXqbxLwQpyZQWEbTSriUeU8uTKj9yOW32hsskV9Klg==",
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-4frc+MZ4iQoREX6KlGjFDYKz5o1tFJrzQrAFH8NOmx3urRkbzp8UZvVOwkvsFNR0/HKOOlcCxN5soA7CXgutNg==",
       "dev": true,
       "requires": {
-        "@firebase/analytics-types": "0.4.0",
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.5.0",
+        "@firebase/installations": "0.0.900-exp.d92a36260",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.4",
-        "tslib": "^1.11.1"
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/analytics-compat": {
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-EvRlp9JWo4S8MmZrP8zovyGra2lWhOwrWeOpURObmHruBqX62+yxEYWK+titKvasZbPoF3+gOpcAFYTiYDiASw==",
+      "dev": true,
+      "requires": {
+        "@firebase/analytics": "0.0.900-exp.d92a36260",
+        "@firebase/analytics-types": "0.4.0",
+        "@firebase/component": "0.5.0",
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         }
       }
@@ -33,153 +53,302 @@
       "dev": true
     },
     "@firebase/app": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.13.tgz",
-      "integrity": "sha512-xGrJETzvCb89VYbGSHFHCW7O/y067HRxT7MGehUE1xMxdPVBDNayHnxEuKwzfGvXAjVmajXBKFlKxaCWpgSjCQ==",
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-dfGglnvjjovCcmsSj1FBNhtptueqQMjw0yw7thGPeoefgEhPkV/ti1QMAjWb9j2SF9/kYRDiCFp53E4wrbVGZQ==",
       "dev": true,
       "requires": {
-        "@firebase/app-types": "0.6.1",
-        "@firebase/component": "0.1.21",
+        "@firebase/component": "0.5.0",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.4",
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/app-compat": {
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-OqGNJq30tb6mrGoWLAb+v14H2I0udiODRTP3tHNXizcsf30LjsflA/aaXPgWDZVcX7hFdNcgZYBvI2u+fM0/+Q==",
+      "dev": true,
+      "requires": {
+        "@firebase/app": "0.0.900-exp.d92a36260",
+        "@firebase/component": "0.5.0",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "1.1.0",
         "dom-storage": "2.1.0",
-        "tslib": "^1.11.1",
+        "tslib": "^2.1.0",
         "xmlhttprequest": "1.8.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         }
       }
     },
     "@firebase/app-types": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
-      "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.2.tgz",
+      "integrity": "sha512-2VXvq/K+n8XMdM4L2xy5bYp2ZXMawJXluUIDzUBvMthVR+lhxK4pfFiqr1mmDbv9ydXvEAuFsD+6DpcZuJcSSw==",
       "dev": true
     },
     "@firebase/auth": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.15.3.tgz",
-      "integrity": "sha512-nGJ0sVRgfd6ly4MyKhc1wyVoINLpQsxJ7uasw30qTssPdDQFus8uDu6Kmy0nN2XzRpYAfchQzZRHE9Q5Y2FHqA==",
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-DH3I9Tml7dQCn9bJGgt2MVLiiKbtXmw9+GBzdHlSN8hCkwJk3yAxZvKobDtpIcJZozNkL4vGZnc39Gy5o1UcaQ==",
       "dev": true,
       "requires": {
-        "@firebase/auth-types": "0.10.1"
-      }
-    },
-    "@firebase/auth-interop-types": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz",
-      "integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw==",
-      "dev": true
-    },
-    "@firebase/auth-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.1.tgz",
-      "integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw==",
-      "dev": true
-    },
-    "@firebase/component": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.21.tgz",
-      "integrity": "sha512-kd5sVmCLB95EK81Pj+yDTea8pzN2qo/1yr0ua9yVi6UgMzm6zAeih73iVUkaat96MAHy26yosMufkvd3zC4IKg==",
-      "dev": true,
-      "requires": {
-        "@firebase/util": "0.3.4",
-        "tslib": "^1.11.1"
+        "@firebase/component": "0.5.0",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "1.1.0",
+        "node-fetch": "2.6.1",
+        "selenium-webdriver": "4.0.0-beta.1",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/auth-compat": {
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-6kB4QU9aLl/y69dVrTVAvHCSPHLxUUb/mohy1x36n2nLqhbTZEx7NO/BBUxhW1G5oOZuOHunsHM9KVPfHvsl5Q==",
+      "dev": true,
+      "requires": {
+        "@firebase/auth": "0.0.900-exp.d92a36260",
+        "@firebase/auth-types": "0.10.3",
+        "@firebase/component": "0.5.0",
+        "@firebase/util": "1.1.0",
+        "node-fetch": "2.6.1",
+        "selenium-webdriver": "^4.0.0-beta.2",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "selenium-webdriver": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-beta.3.tgz",
+          "integrity": "sha512-R0mGHpQkSKgIWiPgcKDcckh4A6aaK0KTyWxs5ieuiI7zsXQ+Kb6neph+dNoeqq3jSBGyv3ONo2w3oohoL4D/Rg==",
+          "dev": true,
+          "requires": {
+            "jszip": "^3.5.0",
+            "rimraf": "^2.7.1",
+            "tmp": "^0.2.1",
+            "ws": "^7.3.1"
+          }
+        },
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/auth-interop-types": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
+      "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==",
+      "dev": true
+    },
+    "@firebase/auth-types": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.3.tgz",
+      "integrity": "sha512-zExrThRqyqGUbXOFrH/sowuh2rRtfKHp9SBVY2vOqKWdCX1Ztn682n9WLtlUDsiYVIbBcwautYWk2HyCGFv0OA==",
+      "dev": true
+    },
+    "@firebase/component": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.0.tgz",
+      "integrity": "sha512-v18csWtXb0ri+3m7wuGLY/UDgcb89vuMlZGQ//+7jEPLIQeLbylvZhol1uzW9WzoOpxMxOS2W5qyVGX36wZvEA==",
+      "dev": true,
+      "requires": {
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         }
       }
     },
     "@firebase/database": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.8.1.tgz",
-      "integrity": "sha512-/1HhR4ejpqUaM9Cn3KSeNdQvdlehWIhdfTVWFxS73ZlLYf7ayk9jITwH10H3ZOIm5yNzxF67p/U7Z/0IPhgWaQ==",
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-kMZFo+kAfxJESVTBdHmzR5g0OAYpKwTZ/nIDlHltexpjpryuKYNnYC4anAy+VZqA404UI5VJrcGO1twSnkZVQA==",
       "dev": true,
       "requires": {
-        "@firebase/auth-interop-types": "0.1.5",
-        "@firebase/component": "0.1.21",
-        "@firebase/database-types": "0.6.1",
+        "@firebase/auth-interop-types": "0.1.6",
+        "@firebase/component": "0.5.0",
+        "@firebase/database-types": "0.7.2",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.4",
+        "@firebase/util": "1.1.0",
         "faye-websocket": "0.11.3",
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/database-compat": {
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-7ZG8qtShlxsIuqWOT2VOGtUVkqVzr+kmwSQS0fTvrfg30gE9rkVZpoLTk3tzAae16g19WRScN8y5r8P9JlCVXQ==",
+      "dev": true,
+      "requires": {
+        "@firebase/auth-interop-types": "0.1.6",
+        "@firebase/component": "0.5.0",
+        "@firebase/database": "0.0.900-exp.d92a36260",
+        "@firebase/database-types": "0.7.2",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "1.1.0",
+        "faye-websocket": "0.11.3",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         }
       }
     },
     "@firebase/database-types": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.6.1.tgz",
-      "integrity": "sha512-JtL3FUbWG+bM59iYuphfx9WOu2Mzf0OZNaqWiQ7lJR8wBe7bS9rIm9jlBFtksB7xcya1lZSQPA/GAy2jIlMIkA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.2.tgz",
+      "integrity": "sha512-cdAd/dgwvC0r3oLEDUR+ULs1vBsEvy0b27nlzKhU6LQgm9fCDzgaH9nFGv8x+S9dly4B0egAXkONkVoWcOAisg==",
       "dev": true,
       "requires": {
-        "@firebase/app-types": "0.6.1"
+        "@firebase/app-types": "0.6.2"
       }
     },
     "@firebase/firestore": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.0.5.tgz",
-      "integrity": "sha512-RBA2A/tnA6ZFQY3pD0TJXRzjB9+D+zaLXzvTVxTO/Sxt8l2cRNFiQhYvHihD6aV/jm3n7RUQ2U7TDtzfXq7jjQ==",
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-8nJj/RddME9onM6JXmszvHUmv1Wn486+nNgRRNpRRnBP83++gZH8pYTsV6yXjITG9gCqZP+fe+j3dkX1SIl7Sw==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/firestore-types": "2.0.0",
+        "@firebase/component": "0.5.0",
+        "@firebase/firestore-types": "2.3.0",
         "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.4",
+        "@firebase/util": "1.1.0",
         "@firebase/webchannel-wrapper": "0.4.1",
         "@grpc/grpc-js": "^1.0.0",
         "@grpc/proto-loader": "^0.5.0",
         "node-fetch": "2.6.1",
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/firestore-compat": {
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-Rp7/4hjeQvqr4bDBjbJ1ZwuUiBoqTPLDD/V3LaN1FAC9WTtd2AqQ8vbGZGNwkJjUBYdyqng2/22kYM1elwI39Q==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.0",
+        "@firebase/firestore": "0.0.900-exp.d92a36260",
+        "@firebase/firestore-types": "2.3.0",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "1.1.0",
+        "@firebase/webchannel-wrapper": "0.4.1",
+        "@grpc/grpc-js": "^1.0.0",
+        "@grpc/proto-loader": "^0.5.0",
+        "node-fetch": "2.6.1",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         }
       }
     },
     "@firebase/firestore-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.0.0.tgz",
-      "integrity": "sha512-ZGb7p1SSQJP0Z+kc9GAUi+Fx5rJatFddBrS1ikkayW+QHfSIz0omU23OgSHcBGTxe8dJCeKiKA2Yf+tkDKO/LA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.3.0.tgz",
+      "integrity": "sha512-QTW7NP7nDL0pgT/X53lyj+mIMh4nRQBBTBlRNQBt7eSyeqBf3ag3bxdQhCg358+5KbjYTC2/O6QtX9DlJZmh1A==",
       "dev": true
     },
     "@firebase/functions": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.1.tgz",
-      "integrity": "sha512-xNCAY3cLlVWE8Azf+/84OjnaXMoyUstJ3vwVRG0ie22QhsdQuPa1tXTiPX4Tmm+Hbbd/Aw0A/7dkEnuW+zYzaQ==",
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-Aeg9lgAzn4tQTW3WO3D3fwMSFlgxVIDapQtJGoMt/hacQfXza/Hd38/9PHbxmU6YJI5qAhfw9YfK8zt24lKiaA==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/functions-types": "0.4.0",
+        "@firebase/component": "0.5.0",
         "@firebase/messaging-types": "0.5.0",
+        "@firebase/util": "1.1.0",
         "node-fetch": "2.6.1",
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/functions-compat": {
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-ku4M/YM1mjyV4RzObRFR/GO0VKDncGupcJxKp9A9f6YDOGvDxm78Y5JiBL26aHbHkcsqts6MFOWgnFFT2RmCkA==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.0",
+        "@firebase/functions": "0.0.900-exp.d92a36260",
+        "@firebase/functions-types": "0.4.0",
+        "@firebase/messaging-types": "0.5.0",
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         }
       }
@@ -191,31 +360,24 @@
       "dev": true
     },
     "@firebase/installations": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.19.tgz",
-      "integrity": "sha512-QqAQzosKVVqIx7oMt5ujF4NsIXgtlTnej4JXGJ8sQQuJoMnt3T+PFQRHbr7uOfVaBiHYhEaXCcmmhfKUHwKftw==",
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-GumdObyp2intMDZfp1SZFmqtlrMweqWI0vr6KGVTkUTQRZFlkaQlBto9Ii6PKuB3X8hHIHvXe/h2aMlaKZPRZQ==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations-types": "0.3.4",
-        "@firebase/util": "0.3.4",
+        "@firebase/component": "0.5.0",
+        "@firebase/util": "1.1.0",
         "idb": "3.0.2",
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         }
       }
-    },
-    "@firebase/installations-types": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.3.4.tgz",
-      "integrity": "sha512-RfePJFovmdIXb6rYwtngyxuEcWnOrzdZd9m7xAW0gRxDIjBT20n3BOhjpmgRWXo/DAxRmS7bRjWAyTHY9cqN7Q==",
-      "dev": true
     },
     "@firebase/logger": {
       "version": "0.2.6",
@@ -224,23 +386,43 @@
       "dev": true
     },
     "@firebase/messaging": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.3.tgz",
-      "integrity": "sha512-63nOP2SmQJrj9jrhV3K96L5MRKS6AqmFVLX1XbGk6K6lz38ZC4LIoCcHxzUBXY7fCAuZvNmh/YB3pE8B2mTs8A==",
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-LApkFwEVNK6L4CaU/D2PukoPsd+tXqsPTzlGSMK9R01WWTNqEpYDVKiCKTTgucN0RAdwSeTqcVdebetDqGl7Eg==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
-        "@firebase/messaging-types": "0.5.0",
-        "@firebase/util": "0.3.4",
+        "@firebase/component": "0.5.0",
+        "@firebase/installations": "0.0.900-exp.d92a36260",
+        "@firebase/util": "1.1.0",
         "idb": "3.0.2",
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/messaging-compat": {
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-pETqergTywJIebd2AAcePW4HgZP2AybbGW3iZ6VfHK1wBNML05EyM9QojQVmN7I408YDisnl4stDGm8KNLlJJA==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.0",
+        "@firebase/installations": "0.0.900-exp.d92a36260",
+        "@firebase/messaging": "0.0.900-exp.d92a36260",
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         }
       }
@@ -252,23 +434,44 @@
       "dev": true
     },
     "@firebase/performance": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.4.tgz",
-      "integrity": "sha512-CY/fzz7qGQ9hUkvOow22MeJhayHSjXmI4+0AqcxaUC4CWk4oQubyIC4pk62aH+yCwZNNeC7JJUEDbtqI/0rGkQ==",
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-vRA7x46mPFNzqS6osFUckvT2krDk4Oo+2svF1QnK2W7hibI52yBlkl2ennhKPDQFYtdTVP5qsS16N/EjGqxsTw==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.5.0",
+        "@firebase/installations": "0.0.900-exp.d92a36260",
         "@firebase/logger": "0.2.6",
-        "@firebase/performance-types": "0.0.13",
-        "@firebase/util": "0.3.4",
-        "tslib": "^1.11.1"
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/performance-compat": {
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-m2XZMCm3c6i0eu8YoZLAuoXsCJuKFvMY5sBPe4uD+6OwVG/xEva5bZ3GHcgM+obMl/V5T6Zj4IxNYGqdz6pquQ==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.0",
+        "@firebase/logger": "0.2.6",
+        "@firebase/performance": "0.0.900-exp.d92a36260",
+        "@firebase/performance-types": "0.0.13",
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         }
       }
@@ -279,35 +482,45 @@
       "integrity": "sha512-6fZfIGjQpwo9S5OzMpPyqgYAUZcFzZxHFqOyNtorDIgNXq33nlldTL/vtaUZA8iT9TT5cJlCrF/jthKU7X21EA==",
       "dev": true
     },
-    "@firebase/polyfill": {
-      "version": "0.3.36",
-      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.36.tgz",
-      "integrity": "sha512-zMM9oSJgY6cT2jx3Ce9LYqb0eIpDE52meIzd/oe/y70F+v9u1LDqk5kUF5mf16zovGBWMNFmgzlsh6Wj0OsFtg==",
-      "dev": true,
-      "requires": {
-        "core-js": "3.6.5",
-        "promise-polyfill": "8.1.3",
-        "whatwg-fetch": "2.0.4"
-      }
-    },
     "@firebase/remote-config": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.30.tgz",
-      "integrity": "sha512-LAfLDcp1AN0V/7AkxBuTKy+Qnq9fKYKxbA5clrXRNVzJbTVnF5eFGsaUOlkes0ESG6lbqKy5ZcDgdl73zBIhAA==",
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-ErsvuzOdygagpnZCLKnolwS3BmIL8aFXhy7FxT3kE1EssyyzcOl5RKXzQoXf9YvQxpKANhiI9gwqsOv/E7VLUQ==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
+        "@firebase/component": "0.5.0",
+        "@firebase/installations": "0.0.900-exp.d92a36260",
         "@firebase/logger": "0.2.6",
-        "@firebase/remote-config-types": "0.1.9",
-        "@firebase/util": "0.3.4",
-        "tslib": "^1.11.1"
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/remote-config-compat": {
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-4mSfmXxYYRM2J6nPiIbsOHlXffV7clzBkez+ZmThVoTpU50kbByfDPRnW04zECMk9xtIGuVMDIPBPRG4KBdu0g==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.0",
+        "@firebase/logger": "0.2.6",
+        "@firebase/remote-config": "0.0.900-exp.d92a36260",
+        "@firebase/remote-config-types": "0.1.9",
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         }
       }
@@ -319,44 +532,65 @@
       "dev": true
     },
     "@firebase/storage": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.2.tgz",
-      "integrity": "sha512-87CrvKrf8kijVekRBmUs8htsNz7N5X/pDhv3BvJBqw8K65GsUolpyjx0f4QJRkCRUYmh3MSkpa5P08lpVbC6nQ==",
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-lCvHf6NyPVc1orAjnhXYYhvJNxeb+8ehbYEEBBtd+LDV5prySOFWt5XmC/jKCAUnkoy/cx8KZV6JU70mvT+ZiQ==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/storage-types": "0.3.13",
-        "@firebase/util": "0.3.4",
-        "tslib": "^1.11.1"
+        "@firebase/component": "0.5.0",
+        "@firebase/storage-types": "0.4.1",
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/storage-compat": {
+      "version": "0.0.900-exp.d92a36260",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.0.900-exp.d92a36260.tgz",
+      "integrity": "sha512-5q34PvZ0G7MVAN9JjSKY512jYqMjIr12KbBdorsELb4+tx24EmS7z5XiWbtx4NsArV/KBN/MGFdprZ9K9996wg==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.0",
+        "@firebase/storage": "0.0.900-exp.d92a36260",
+        "@firebase/storage-types": "0.4.1",
+        "@firebase/util": "1.1.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         }
       }
     },
     "@firebase/storage-types": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
-      "integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.4.1.tgz",
+      "integrity": "sha512-IM4cRzAnQ6QZoaxVZ5MatBzqXVcp47hOlE28jd9xXw1M9V7gfjhmW0PALGFQx58tPVmuUwIKyoEbHZjV4qRJwQ==",
       "dev": true
     },
     "@firebase/util": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.4.tgz",
-      "integrity": "sha512-VwjJUE2Vgr2UMfH63ZtIX9Hd7x+6gayi6RUXaTqEYxSbf/JmehLmAEYSuxS/NckfzAXWeGnKclvnXVibDgpjQQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.1.0.tgz",
+      "integrity": "sha512-lfuSASuPKNdfebuFR8rjFamMQUPH9iiZHcKS755Rkm/5gRT0qC7BMhCh3ZkHf7NVbplzIc/GhmX2jM+igDRCag==",
       "dev": true,
       "requires": {
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         }
       }
@@ -368,20 +602,18 @@
       "dev": true
     },
     "@grpc/grpc-js": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.2.tgz",
-      "integrity": "sha512-iK/T984Ni6VnmlQK/LJdUk+VsXSaYIWkgzJ0LyOcxN2SowAmoRjG28kS7B1ui/q/MAv42iM3051WBt5QorFxmg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.3.2.tgz",
+      "integrity": "sha512-UXepkOKCATJrhHGsxt+CGfpZy9zUn1q9mop5kfcXq1fBkTePxVNPOdnISlCbJFlCtld+pSLGyZCzr9/zVprFKA==",
       "dev": true,
       "requires": {
-        "@types/node": "^12.12.47",
-        "google-auth-library": "^6.1.1",
-        "semver": "^6.2.0"
+        "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.5.tgz",
-      "integrity": "sha512-WwN9jVNdHRQoOBo9FDH7qU+mgfjPc8GygPYms3M+y3fbQLfnCe/Kv/E01t7JRgnrsOHH8euvSbed3mIalXhwqQ==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.6.tgz",
+      "integrity": "sha512-DT14xgw3PSzPxwS13auTEwxhMMOoz33DPUKNtmYK/QYbBSpLXJy78FGGs5yVoxVobEqPm4iW9MOIoz0A3bLTRQ==",
       "dev": true,
       "requires": {
         "lodash.camelcase": "^4.3.0",
@@ -474,9 +706,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.8.tgz",
-      "integrity": "sha512-D4k2kNi0URNBxIRCb1khTnkWNHv8KSL1owPmS/K5e5t8B2GzMReY7AsJIY1BnP5KdlgC4rj9jk2IkDMasIE7xg==",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
+      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==",
       "dev": true
     },
     "@types/prop-types": {
@@ -495,15 +727,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
-    },
     "acorn": {
       "version": "5.7.4",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
@@ -519,37 +742,10 @@
         "acorn": "^5.0.0"
       }
     },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "requires": {
-        "debug": "4"
-      }
-    },
-    "arrify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-      "dev": true
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
-    },
-    "bignumber.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
       "dev": true
     },
     "brace-expansion": {
@@ -561,12 +757,6 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
-    },
-    "buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-      "dev": true
     },
     "builtin-modules": {
       "version": "2.0.0",
@@ -592,10 +782,10 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "core-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "csstype": {
@@ -613,52 +803,16 @@
         "time-zone": "^1.0.0"
       }
     },
-    "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
-      "requires": {
-        "ms": "2.1.2"
-      }
-    },
     "dom-storage": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
       "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
       "dev": true
     },
-    "ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "estree-walker": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-      "dev": true
-    },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
-    },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
-    },
-    "fast-text-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==",
       "dev": true
     },
     "faye-websocket": {
@@ -671,25 +825,31 @@
       }
     },
     "firebase": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.1.2.tgz",
-      "integrity": "sha512-I1nYPQpE22sKWKc4A4GQNl0k0G1IbPZ5KvyzwEP4fAkLSX9j1rNwh7S902CJIjUxOXV/QOU7e/gYtNRc5SX98Q==",
+      "version": "9.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-9.0.0-beta.2.tgz",
+      "integrity": "sha512-gbcJ2sg/ECEP72sn2o4CRI2EjoF0r+v9jZ6zOZ1E/keWpTbZacWvMT4troW9LSmY5lxGBE2grl+EoWSD57Jrdg==",
       "dev": true,
       "requires": {
-        "@firebase/analytics": "0.6.2",
-        "@firebase/app": "0.6.13",
-        "@firebase/app-types": "0.6.1",
-        "@firebase/auth": "0.15.3",
-        "@firebase/database": "0.8.1",
-        "@firebase/firestore": "2.0.5",
-        "@firebase/functions": "0.6.1",
-        "@firebase/installations": "0.4.19",
-        "@firebase/messaging": "0.7.3",
-        "@firebase/performance": "0.4.4",
-        "@firebase/polyfill": "0.3.36",
-        "@firebase/remote-config": "0.1.30",
-        "@firebase/storage": "0.4.2",
-        "@firebase/util": "0.3.4"
+        "@firebase/analytics": "0.0.900-exp.d92a36260",
+        "@firebase/analytics-compat": "0.0.900-exp.d92a36260",
+        "@firebase/app": "0.0.900-exp.d92a36260",
+        "@firebase/app-compat": "0.0.900-exp.d92a36260",
+        "@firebase/auth": "0.0.900-exp.d92a36260",
+        "@firebase/auth-compat": "0.0.900-exp.d92a36260",
+        "@firebase/database": "0.0.900-exp.d92a36260",
+        "@firebase/database-compat": "0.0.900-exp.d92a36260",
+        "@firebase/firestore": "0.0.900-exp.d92a36260",
+        "@firebase/firestore-compat": "0.0.900-exp.d92a36260",
+        "@firebase/functions": "0.0.900-exp.d92a36260",
+        "@firebase/functions-compat": "0.0.900-exp.d92a36260",
+        "@firebase/messaging": "0.0.900-exp.d92a36260",
+        "@firebase/messaging-compat": "0.0.900-exp.d92a36260",
+        "@firebase/performance": "0.0.900-exp.d92a36260",
+        "@firebase/performance-compat": "0.0.900-exp.d92a36260",
+        "@firebase/remote-config": "0.0.900-exp.d92a36260",
+        "@firebase/remote-config-compat": "0.0.900-exp.d92a36260",
+        "@firebase/storage": "0.0.900-exp.d92a36260",
+        "@firebase/storage-compat": "0.0.900-exp.d92a36260"
       }
     },
     "fs-extra": {
@@ -709,29 +869,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "gaxios": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
-      "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
-      "dev": true,
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.3.0"
-      }
-    },
-    "gcp-metadata": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
-      "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
-      "dev": true,
-      "requires": {
-        "gaxios": "^4.0.0",
-        "json-bigint": "^1.0.0"
-      }
-    },
     "glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -746,70 +883,28 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "google-auth-library": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.3.tgz",
-      "integrity": "sha512-m9mwvY3GWbr7ZYEbl61isWmk+fvTmOt0YNUfPOUY2VH8K5pZlAIWJjxEi0PqR3OjMretyiQLI6GURMrPSwHQ2g==",
-      "dev": true,
-      "requires": {
-        "arrify": "^2.0.0",
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "fast-text-encoding": "^1.0.0",
-        "gaxios": "^4.0.0",
-        "gcp-metadata": "^4.2.0",
-        "gtoken": "^5.0.4",
-        "jws": "^4.0.0",
-        "lru-cache": "^6.0.0"
-      }
-    },
-    "google-p12-pem": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
-      "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
-      "dev": true,
-      "requires": {
-        "node-forge": "^0.10.0"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
       "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
       "dev": true
     },
-    "gtoken": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.1.0.tgz",
-      "integrity": "sha512-4d8N6Lk8TEAHl9vVoRVMh9BNOKWVgl2DdNtr3428O75r3QFrF/a5MMu851VmK0AA8+iSvbwRv69k5XnMLURGhg==",
-      "dev": true,
-      "requires": {
-        "gaxios": "^4.0.0",
-        "google-p12-pem": "^3.0.3",
-        "jws": "^4.0.0",
-        "mime": "^2.2.0"
-      }
-    },
     "http-parser-js": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.2.tgz",
-      "integrity": "sha512-opCO9ASqg5Wy2FNo7A0sxy71yGbbkJJXLdgMK04Tcypw9jr2MgWbyubb0+WdmDmGnFflO7fRbqbaihh/ENDlRQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
       "dev": true
-    },
-    "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      }
     },
     "idb": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
       "integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==",
+      "dev": true
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
       "dev": true
     },
     "inflight": {
@@ -843,10 +938,10 @@
         "@types/estree": "0.0.39"
       }
     },
-    "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "js-tokens": {
@@ -854,15 +949,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
-    },
-    "json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "dev": true,
-      "requires": {
-        "bignumber.js": "^9.0.0"
-      }
     },
     "jsonfile": {
       "version": "3.0.1",
@@ -873,25 +959,25 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+    "jszip": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
       "dev": true,
       "requires": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
       }
     },
-    "jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
       "dev": true,
       "requires": {
-        "jwa": "^2.0.0",
-        "safe-buffer": "^5.0.1"
+        "immediate": "~3.0.5"
       }
     },
     "locate-character": {
@@ -921,15 +1007,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "magic-string": {
       "version": "0.22.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
@@ -938,12 +1015,6 @@
       "requires": {
         "vlq": "^0.2.2"
       }
-    },
-    "mime": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -954,22 +1025,10 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
-    },
-    "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "object-assign": {
@@ -986,6 +1045,12 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
     },
     "parse-ms": {
       "version": "1.0.1",
@@ -1036,16 +1101,16 @@
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
-    "promise-polyfill": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
-      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "protobufjs": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
-      "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
       "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -1059,16 +1124,8 @@
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
         "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
+        "@types/node": ">=13.7.0",
         "long": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.35",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.35.tgz",
-          "integrity": "sha512-q9aeOGwv+RRou/ca4aJVUM/jD5u7LBexu+rq9PkA/NhHNn8JifcMo94soKm0b6JGSfw/PSNdqtc428OscMvEYA==",
-          "dev": true
-        }
       }
     },
     "react": {
@@ -1079,6 +1136,21 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "require-relative": {
@@ -1218,15 +1290,38 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
-    "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+    "selenium-webdriver": {
+      "version": "4.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-beta.1.tgz",
+      "integrity": "sha512-DJ10z6Yk+ZBaLrt1CLElytQ/FOayx29ANKDtmtyW1A6kCJx3+dsc5fFMOZxwzukDniyYsC3OObT5pUAsgkjpxQ==",
+      "dev": true,
+      "requires": {
+        "jszip": "^3.5.0",
+        "rimraf": "^2.7.1",
+        "tmp": "^0.2.1",
+        "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
     "signal-exit": {
@@ -1247,11 +1342,40 @@
       "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "time-zone": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
       "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
       "dev": true
+    },
+    "tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "requires": {
+        "rimraf": "^3.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "tslib": {
       "version": "1.9.3",
@@ -1298,6 +1422,12 @@
         }
       }
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
     "vlq": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
@@ -1321,28 +1451,22 @@
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
     },
-    "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "dev": true
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true
+    },
     "xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
       "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-      "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {},
   "devDependencies": {
     "@types/react": "^17.0.0",
-    "firebase": "^8.0.0",
+    "firebase": "9.0.0-beta.2",
     "path": "^0.12.7",
     "prettier": "2.2.1",
     "react": "^17.0.1",
@@ -67,7 +67,7 @@
   },
   "peerDependencies": {
     "react": ">= 16.8.0",
-    "firebase": ">= 8.0.0"
+    "firebase": ">= 9.0.0-beta.2"
   },
   "typings": "index.d.ts"
 }

--- a/storage/useDownloadURL.ts
+++ b/storage/useDownloadURL.ts
@@ -1,15 +1,15 @@
-import firebase from 'firebase/app';
+import { FirebaseStorageError, StorageReference, getDownloadURL } from 'firebase/storage';
 import { useEffect } from 'react';
 import { LoadingHook, useComparatorRef, useLoadingValue } from '../util';
 
-export type DownloadURLHook = LoadingHook<string, firebase.FirebaseError>;
+export type DownloadURLHook = LoadingHook<string, FirebaseStorageError>;
 
 export default (
-  storageRef?: firebase.storage.Reference | null
+  storageRef?: StorageReference | null
 ): DownloadURLHook => {
   const { error, loading, reset, setError, setValue, value } = useLoadingValue<
     string,
-    firebase.FirebaseError
+    FirebaseStorageError
   >();
   const ref = useComparatorRef(storageRef, isEqual, reset);
 
@@ -18,15 +18,15 @@ export default (
       setValue(undefined);
       return;
     }
-    ref.current.getDownloadURL().then(setValue).catch(setError);
+    getDownloadURL(ref.current).then(setValue).catch(setError);
   }, [ref.current]);
 
   return [value, loading, error];
 };
 
 const isEqual = (
-  v1: firebase.storage.Reference | null | undefined,
-  v2: firebase.storage.Reference | null | undefined
+  v1: StorageReference | null | undefined,
+  v2: StorageReference | null | undefined
 ): boolean => {
   const bothNull: boolean = !v1 && !v2;
   const equal: boolean = !!v1 && !!v2 && v1.fullPath === v2.fullPath;


### PR DESCRIPTION
Adds support for Firebase 9.

Closes #105 

Firestore and Database hooks are using the compat imports currently, as I'm not familiar with those APIs. In order to get the full tree-shaking improvements of Firebase 9, these compat imports will need to be updated.