### PR TITLE
Enable Query generics

### DIFF
--- a/firestore/useCollection.ts
+++ b/firestore/useCollection.ts
@@ -13,7 +13,7 @@ import {
 import { useIsEqualRef, useLoadingValue } from '../util';
 
 export const useCollection = <T = firebase.firestore.DocumentData>(
-  query?: firebase.firestore.Query | null,
+  query?: firebase.firestore.Query<T> | null,
   options?: Options
 ): CollectionHook<T> => {
   return useCollectionInternal<T>(true, query, options);
@@ -31,7 +31,7 @@ export const useCollectionData = <
   IDField extends string = '',
   RefField extends string = ''
 >(
-  query?: firebase.firestore.Query | null,
+  query?: firebase.firestore.Query<T> | null,
   options?: DataOptions<T>
 ): CollectionDataHook<T, IDField, RefField> => {
   return useCollectionDataInternal<T, IDField, RefField>(true, query, options);
@@ -42,7 +42,7 @@ export const useCollectionDataOnce = <
   IDField extends string = '',
   RefField extends string = ''
 >(
-  query?: firebase.firestore.Query | null,
+  query?: firebase.firestore.Query<T> | null,
   options?: OnceDataOptions<T>
 ): CollectionDataHook<T, IDField, RefField> => {
   return useCollectionDataInternal<T, IDField, RefField>(false, query, options);
@@ -50,7 +50,7 @@ export const useCollectionDataOnce = <
 
 const useCollectionInternal = <T = firebase.firestore.DocumentData>(
   listen: boolean,
-  query?: firebase.firestore.Query | null,
+  query?: firebase.firestore.Query<T> | null,
   options?: Options & OnceOptions
 ) => {
   const { error, loading, reset, setError, setValue, value } = useLoadingValue<
@@ -99,7 +99,7 @@ const useCollectionDataInternal = <
   RefField extends string = ''
 >(
   listen: boolean,
-  query?: firebase.firestore.Query | null,
+  query?: firebase.firestore.Query<T> | null,
   options?: DataOptions<T> & OnceDataOptions<T>
 ): CollectionDataHook<T, IDField, RefField> => {
   const idField = options ? options.idField : undefined;


### PR DESCRIPTION
for #120 

If you want type info, use [`withConverter`](https://firebase.google.com/docs/reference/js/firebase.firestore.FirestoreDataConverter).

```ts
interface Task {
  title: string;
  message: string;
}

const converter = {
  toFirestore: (data: Task): firebase.firestore.DocumentData => {
    return { title: data.title, message: data.message };
  },
  fromFirestore: (
    snap: firebase.firestore.QueryDocumentSnapshot,
    options: firebase.firestore.SnapshotOptions
  ): Task => {
    const data = snap.data(options);
    return { title: data.title, message: data.message };
  },
};

const [tasks, loading, error] 
  = useCollectionData(firebase.firestore().collection('tasks').withConverter(converter));
```

Sorry, but I don't care about `useDocument` changed at 33b8a61f4da3c8499a5f1000022209cfa97d2ba1