### PR TITLE
Fix AuthActionHooks type from 'void' to 'Promise<void>'

### DIFF
--- a/auth/types.ts
+++ b/auth/types.ts
@@ -1,7 +1,7 @@
 import firebase from 'firebase/app';
 
 export type AuthActionHook<T, E> = [
-  (email: string, password: string) => void,
+  (email: string, password: string) => Promise<void>,
   T | undefined,
   boolean,
   E | undefined


### PR DESCRIPTION
## Overview
Fix`AuthActionHooks` type from `void` to `Promise<void>`.

## Why
The type of `signInWithEmailAndPassword` and `createUserWithEmailAndPassword` are `(email: string, password: string) => Promise<void>`

But `AuthActionHooks` type is `(email: string, password: string) => void`.  so, the type of these functions is wrong, so I created this PR!

Thanks for the great library!

