### PR TITLE
Updated auth README changing the user return type, if not logged in, …

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -28,7 +28,7 @@ The `useAuthState` hook takes the following parameters:
 
 Returns:
 
-- `user`: The `firebase.User` if logged in, or `undefined` if not
+- `user`: The `firebase.User` if logged in, or `null` if not
 - `loading`: A `boolean` to indicate whether the the authentication state is still being loaded
 - `error`: Any `firebase.auth.Error` returned by Firebase when trying to load the user, or `undefined` if there is no error
 


### PR DESCRIPTION
…from undefined to null

For #164.