### PR TITLE
Firebase 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Temporary package to migrate `react-firebase-hooks` to Firebase v9.
+
 # React Firebase Hooks
 
 A set of reusable [React Hooks](https://reactjs.org/docs/hooks-intro.html) for [Firebase](https://firebase.google.com/).
@@ -5,11 +7,13 @@ A set of reusable [React Hooks](https://reactjs.org/docs/hooks-intro.html) for [
 [![npm version](https://img.shields.io/npm/v/react-firebase-hooks.svg?style=flat-square)](https://www.npmjs.com/package/react-firebase-hooks)
 [![npm downloads](https://img.shields.io/npm/dm/react-firebase-hooks.svg?style=flat-square)](https://www.npmjs.com/package/react-firebase-hooks)
 
-**This documentation is for v3 of React Firebase Hooks which involved a number of breaking changes, including adding support for Firebase v8.0.0 - more details [here](https://github.com/CSFrequency/react-firebase-hooks/releases/tag/v3.0.0). For v2 documentation, see [here](https://github.com/CSFrequency/react-firebase-hooks/tree/v2.2.0).**
+This documentation is for v4 of React Firebase Hooks which involved a number of breaking changes, including adding support for Firebase v9 - more details [here](https://github.com/CSFrequency/react-firebase-hooks/releases/tag/v4.0.0). 
+- For v3 documentation (Firebase v8), see [here](https://github.com/CSFrequency/react-firebase-hooks/tree/v3.0.0).
+- For v2 documentation, see [here](https://github.com/CSFrequency/react-firebase-hooks/tree/v2.2.0).
 
 ## Installation
 
-React Firebase Hooks v3 requires **React 16.8.0 or later** and **Firebase v8.0.0 or later**.
+React Firebase Hooks v4 requires **React 16.8.0 or later** and **Firebase v9.0.0 or later**.
 
 > Official support for Hooks was added to React Native in v0.59.0. React Firebase Hooks works with both the Firebase JS SDK and React Native Firebase, although some of the typings may be incorrect.
 
@@ -28,6 +32,10 @@ This assumes that you’re using the [npm](https://npmjs.com) or [yarn](https://
 There has been a **lot** of hype around React Hooks, but this hype merely reflects that there are obvious real world benefits of Hooks to React developers everywhere.
 
 This library explores how React Hooks can work to make integration with Firebase even more straightforward than it already is. It takes inspiration for naming from RxFire and is based on an internal library that we had been using in a number of apps prior to the release of React Hooks. The implementation with hooks is 10x simpler than our previous implementation.
+
+## Upgrading from v3 to v4
+
+To upgrade your project from v3 to v4 check out the [Release Notes](https://github.com/CSFrequency/react-firebase-hooks/releases/tag/v4.0.0) which have full details of everything that needs to be changed.
 
 ## Upgrading from v2 to v3
 

--- a/auth/README.md
+++ b/auth/README.md
@@ -1,6 +1,6 @@
 # React Firebase Hooks - Auth
 
-React Firebase Hooks provides a convenience listener for Firebase Auth's auth state. The hook wraps around the `firebase.auth().onAuthStateChange()` method to ensure that it is always up to date.
+React Firebase Hooks provides a convenience listener for Firebase Auth's auth state. The hook wraps around the `auth.onAuthStateChange(auth.getAuth(firebaseApp))` method to ensure that it is always up to date.
 
 All hooks can be imported from `react-firebase-hooks/auth`, e.g.
 
@@ -24,30 +24,33 @@ Retrieve and monitor the authentication state from Firebase.
 
 The `useAuthState` hook takes the following parameters:
 
-- `auth`: `firebase.auth.Auth` instance for the app you would like to monitor
+- `auth`: `auth.Auth` instance for the app you would like to monitor
 
 Returns:
 
-- `user`: The `firebase.User` if logged in, or `undefined` if not
+- `user`: The `auth.User` if logged in, or `undefined` if not
 - `loading`: A `boolean` to indicate whether the the authentication state is still being loaded
-- `error`: Any `firebase.auth.Error` returned by Firebase when trying to load the user, or `undefined` if there is no error
+- `error`: Any `AuthError` returned by Firebase when trying to load the user, or `undefined` if there is no error
 
 #### If you are registering or signing in the user for the first time consider using [useCreateUserWithEmailAndPassword](#usecreateuserwithemailandpassword), [useSignInWithEmailAndPassword](#usesigninwithemailandpassword)
 
 #### Full Example
 
 ```js
+import { getAuth, signInWithEmailAndPassword, signOut } from 'firebase/auth';
 import { useAuthState } from 'react-firebase-hooks/auth';
 
+const auth = getAuth(firebaseApp)
+
 const login = () => {
-  firebase.auth().signInWithEmailAndPassword('test@test.com', 'password');
+  signInWithEmailAndPassword(auth, 'test@test.com', 'password');
 };
 const logout = () => {
-  firebase.auth().signOut();
+  signOut(auth)
 };
 
 const CurrentUser = () => {
-  const [user, loading, error] = useAuthState(firebase.auth());
+  const [user, loading, error] = useAuthState(auth);
 
   if (loading) {
     return (
@@ -90,17 +93,17 @@ Create a user with email and password. Wraps the underlying `firebase.auth().cre
 
 The `useCreateUserWithEmailAndPassword` hook takes the following parameters:
 
-- `auth`: `firebase.auth.Auth` instance for the app you would like to monitor
+- `auth`: `auth.Auth` instance for the app you would like to monitor
 - `options`: (optional) `Object` with the following parameters:
-  - `emailVerificationOptions`: (optional) `firebase.auth.ActionCodeSettings` to customise the email verification
+  - `emailVerificationOptions`: (optional) `auth.ActionCodeSettings` to customise the email verification
   - `sendEmailVerification`: (optional) `boolean` to trigger sending of an email verification after the user has been created
 
 Returns:
 
 - `createUserWithEmailAndPassword(email: string, password: string)`: a function you can call to start the registration
-- `user`: The `firebase.User` if the user was created or `undefined` if not
+- `user`: The `User` if the user was created or `undefined` if not
 - `loading`: A `boolean` to indicate whether the the user creation is processing
-- `error`: Any `firebase.auth.Error` returned by Firebase when trying to create the user, or `undefined` if there is no error
+- `error`: Any `Error` returned by Firebase when trying to create the user, or `undefined` if there is no error
 
 #### Full Example
 
@@ -165,18 +168,18 @@ const [
 ] = useSignInWithEmailAndPassword(auth, email, password);
 ```
 
-Login a user with email and password. Wraps the underlying `firebase.auth().signInWithEmailAndPassword` method and provides additional `loading` and `error` information.
+Login a user with email and password. Wraps the underlying `auth.signInWithEmailAndPassword` method and provides additional `loading` and `error` information.
 
 The `useSignInWithEmailAndPassword` hook takes the following parameters:
 
-- `auth`: `firebase.auth.Auth` instance for the app you would like to monitor
+- `auth`: `Auth` instance for the app you would like to monitor
 
 Returns:
 
 - `signInWithEmailAndPassword(email: string, password: string)`: a function you can call to start the login
-- `user`: The `firebase.User` if the user was logged in or `undefined` if not
+- `user`: The `auth.User` if the user was logged in or `undefined` if not
 - `loading`: A `boolean` to indicate whether the the user login is processing
-- `error`: Any `firebase.auth.Error` returned by Firebase when trying to login the user, or `undefined` if there is no error
+- `error`: Any `Error` returned by Firebase when trying to login the user, or `undefined` if there is no error
 
 #### Full Example
 

--- a/auth/index.js.flow
+++ b/auth/index.js.flow
@@ -1,7 +1,5 @@
 // @flow
-import type { FirebaseUser as User } from 'firebase';
-import type { Auth } from 'firebase/auth';
-import typeof { Error as AuthError } from 'firebase/auth';
+import type { Auth, AuthError, User } from 'firebase/auth';
 
 type LoadingHook<T> = [T | void, boolean, AuthError | void];
 

--- a/auth/types.ts
+++ b/auth/types.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app';
+import { ActionCodeSettings, AuthError, UserCredential } from 'firebase/auth';
 
 export type AuthActionHook<T, E> = [
   (email: string, password: string) => void,
@@ -7,10 +7,10 @@ export type AuthActionHook<T, E> = [
   E | undefined
 ];
 export type CreateUserOptions = {
-  emailVerificationOptions?: firebase.auth.ActionCodeSettings;
+  emailVerificationOptions?: ActionCodeSettings;
   sendEmailVerification?: boolean;
 };
 export type EmailAndPasswordActionHook = AuthActionHook<
-  firebase.auth.UserCredential,
-  firebase.FirebaseError
+  UserCredential,
+  AuthError
 >;

--- a/auth/useAuthState.ts
+++ b/auth/useAuthState.ts
@@ -1,4 +1,4 @@
-import { Auth, User } from 'firebase/auth';
+import { Auth, onAuthStateChanged, User } from 'firebase/auth';
 import { useEffect, useMemo } from 'react';
 import { LoadingHook, useLoadingValue } from '../util';
 
@@ -11,11 +11,7 @@ export default (auth: Auth): AuthStateHook => {
   >(() => auth.currentUser);
 
   useEffect(() => {
-    const listener = auth.onAuthStateChanged(setValue, setError);
-
-    return () => {
-      listener();
-    };
+    return onAuthStateChanged(auth, setValue, setError);
   }, [auth]);
 
   const resArray: AuthStateHook = [value, loading, error];

--- a/auth/useAuthState.ts
+++ b/auth/useAuthState.ts
@@ -1,16 +1,13 @@
-import firebase from 'firebase/app';
+import { Auth, User } from 'firebase/auth';
 import { useEffect, useMemo } from 'react';
 import { LoadingHook, useLoadingValue } from '../util';
 
-export type AuthStateHook = LoadingHook<
-  firebase.User | null,
-  firebase.auth.Error
->;
+export type AuthStateHook = LoadingHook<User | null, Error>;
 
-export default (auth: firebase.auth.Auth): AuthStateHook => {
+export default (auth: Auth): AuthStateHook => {
   const { error, loading, setError, setValue, value } = useLoadingValue<
-    firebase.User | null,
-    firebase.auth.Error
+    User | null,
+    Error
   >(() => auth.currentUser);
 
   useEffect(() => {

--- a/auth/useCreateUserWithEmailAndPassword.ts
+++ b/auth/useCreateUserWithEmailAndPassword.ts
@@ -1,16 +1,19 @@
+import {
+  Auth,
+  UserCredential,
+  createUserWithEmailAndPassword as firebaseCreateUserWithEmailAndPassword,
+  sendEmailVerification,
+  AuthError,
+} from 'firebase/auth';
 import { useState, useMemo } from 'react';
-import firebase from 'firebase/app';
 import { CreateUserOptions, EmailAndPasswordActionHook } from './types';
 
 export default (
-  auth: firebase.auth.Auth,
+  auth: Auth,
   options?: CreateUserOptions
 ): EmailAndPasswordActionHook => {
-  const [error, setError] = useState<firebase.FirebaseError>();
-  const [
-    registeredUser,
-    setRegisteredUser,
-  ] = useState<firebase.auth.UserCredential>();
+  const [error, setError] = useState<AuthError>();
+  const [registeredUser, setRegisteredUser] = useState<UserCredential>();
   const [loading, setLoading] = useState<boolean>(false);
 
   const createUserWithEmailAndPassword = async (
@@ -19,14 +22,21 @@ export default (
   ) => {
     setLoading(true);
     try {
-      const user = await auth.createUserWithEmailAndPassword(email, password);
+      const user = await firebaseCreateUserWithEmailAndPassword(
+        auth,
+        email,
+        password
+      );
       if (options && options.sendEmailVerification && user.user) {
-        await user.user.sendEmailVerification(options.emailVerificationOptions);
+        await sendEmailVerification(
+          user.user,
+          options.emailVerificationOptions
+        );
       }
       setRegisteredUser(user);
       setLoading(false);
     } catch (error) {
-      setError(error);
+      setError(error as AuthError);
       setLoading(false);
     }
   };

--- a/auth/useSignInWithEmailAndPassword.ts
+++ b/auth/useSignInWithEmailAndPassword.ts
@@ -1,13 +1,15 @@
+import {
+  Auth,
+  UserCredential,
+  signInWithEmailAndPassword as firebaseSignInWithEmailAndPassword,
+  AuthError,
+} from 'firebase/auth';
 import { useState, useMemo } from 'react';
-import firebase from 'firebase/app';
 import { EmailAndPasswordActionHook } from './types';
 
-export default (auth: firebase.auth.Auth): EmailAndPasswordActionHook => {
-  const [error, setError] = useState<firebase.FirebaseError>();
-  const [
-    loggedInUser,
-    setLoggedInUser,
-  ] = useState<firebase.auth.UserCredential>();
+export default (auth: Auth): EmailAndPasswordActionHook => {
+  const [error, setError] = useState<AuthError>();
+  const [loggedInUser, setLoggedInUser] = useState<UserCredential>();
   const [loading, setLoading] = useState<boolean>(false);
 
   const signInWithEmailAndPassword = async (
@@ -16,11 +18,15 @@ export default (auth: firebase.auth.Auth): EmailAndPasswordActionHook => {
   ) => {
     setLoading(true);
     try {
-      const user = await auth.signInWithEmailAndPassword(email, password);
+      const user = await firebaseSignInWithEmailAndPassword(
+        auth,
+        email,
+        password
+      );
       setLoggedInUser(user);
       setLoading(false);
     } catch (err) {
-      setError(err);
+      setError(err as AuthError);
       setLoading(false);
     }
   };

--- a/database/README.md
+++ b/database/README.md
@@ -1,7 +1,7 @@
 # React Firebase Hooks - Realtime Database
 
 React Firebase Hooks provides convenience listeners for lists and values stored within the
-Firebase Realtime Database. The hooks wrap around the `firebase.database().ref().on()` method.
+Firebase Realtime Database. The hooks wrap around the `onX(ref(firebase, 'path'), ...)` method.
 
 In addition to returning the list or value, the hooks provide an `error` and `loading` property
 to give a complete lifecycle for loading and listening to the Realtime Database.
@@ -14,11 +14,16 @@ import { useList } from 'react-firebase-hooks/database';
 
 List of Realtime Database hooks:
 
-- [useList](#uselist)
-- [useListKeys](#uselistkeys)
-- [useListVals](#uselistvals)
-- [useObject](#useobject)
-- [useObjectVal](#useobjectval)
+- [React Firebase Hooks - Realtime Database](#react-firebase-hooks---realtime-database)
+    - [useList](#uselist)
+      - [Full Example](#full-example)
+    - [useListKeys](#uselistkeys)
+    - [useListVals](#uselistvals)
+    - [useObject](#useobject)
+      - [Full Example](#full-example-1)
+    - [useObjectVal](#useobjectval)
+  - [Transforming data](#transforming-data)
+      - [Full Example](#full-example-2)
 
 Additional functionality:
 
@@ -34,21 +39,24 @@ Retrieve and monitor a list value in the Firebase Realtime Database.
 
 The `useList` hook takes the following parameters:
 
-- `reference`: (optional) `firebase.database.Reference` for the data you would like to load
+- `reference`: (optional) `database.Reference` for the data you would like to load
 
 Returns:
 
-- `snapshots`: an array of `firebase.database.DataSnapshot`, or `undefined` if no reference is supplied
+- `snapshots`: an array of `database.DataSnapshot`, or `undefined` if no reference is supplied
 - `loading`: a `boolean` to indicate if the data is still being loaded
-- `error`: Any `firebase.FirebaseError` returned by Firebase when trying to load the data, or `undefined` if there is no error
+- `error`: Any `Error` returned by Firebase when trying to load the data, or `undefined` if there is no error
 
 #### Full Example
 
 ```js
+import { ref, getDatabase } from 'firebase/database';
 import { useList } from 'react-firebase-hooks/database';
 
+const database = getDatabase(firebaseApp);
+
 const DatabaseList = () => {
-  const [snapshots, loading, error] = useList(firebase.database().ref('list'));
+  const [snapshots, loading, error] = useList(ref(database, 'list'));
 
   return (
     <div>
@@ -77,40 +85,40 @@ const DatabaseList = () => {
 const [keys, loading, error] = useListKeys(reference);
 ```
 
-As `useList`, but this hooks extracts the `firebase.database.DataSnapshot.key` values, rather than the the `firebase.database.DataSnapshot`s themselves.
+As `useList`, but this hooks extracts the `database.DataSnapshot.key` values, rather than the the `database.DataSnapshot`s themselves.
 
 The `useListKeys` hook takes the following parameters:
 
-- `reference`: (optional) `firebase.database.Reference` for the data you would like to load
+- `reference`: (optional) `database.Reference` for the data you would like to load
 
 Returns:
 
 - `keys`: an array of `string`, or `undefined` if no reference is supplied
 - `loading`: a `boolean` to indicate if the data is still being loaded
-- `error`: Any `firebase.FirebaseError` returned by Firebase when trying to load the data, or `undefined` if there is no error
+- `error`: Any `Error` returned by Firebase when trying to load the data, or `undefined` if there is no error
 
 ### useListVals
 
 ```js
-const [values, loading, error] = useListVals < T > (reference, options);
+const [values, loading, error] = useListVals<T> (reference, options);
 ```
 
-As `useList`, but this hook extracts a typed list of the `firebase.database.DataSnapshot.val()` values, rather than the the
-`firebase.database.DataSnapshot`s themselves.
+As `useList`, but this hook extracts a typed list of the `database.DataSnapshot.val()` values, rather than the the
+`database.DataSnapshot`s themselves.
 
 The `useListVals` hook takes the following parameters:
 
-- `reference`: (optional) `firebase.database.Reference` for the data you would like to load
+- `reference`: (optional) `database.Reference` for the data you would like to load
 - `options`: (optional) `Object` with the following parameters:
-  - `keyField`: (optional) `string` field name that should be populated with the `firebase.database.DataSnapshot.id` property in the returned values.
-  - `refField`: (optional) `string` field name that should be populated with the `firebase.database.DataSnapshot.ref` property.
-  - `transform`: (optional) a function that receives the raw `firebase.database.DataSnapshot.val()` for each item in the list to allow manual transformation of the data where required by the application. See [`Transforming data`](#transforming-data) below.
+  - `keyField`: (optional) `string` field name that should be populated with the `database.DataSnapshot.id` property in the returned values.
+  - `refField`: (optional) `string` field name that should be populated with the `database.DataSnapshot.ref` property.
+  - `transform`: (optional) a function that receives the raw `database.DataSnapshot.val()` for each item in the list to allow manual transformation of the data where required by the application. See [`Transforming data`](#transforming-data) below.
 
 Returns:
 
 - `values`: an array of `T`, or `undefined` if no reference is supplied
 - `loading`: a `boolean` to indicate if the data is still being loaded
-- `error`: Any `firebase.FirebaseError` returned by Firebase when trying to load the data, or `undefined` if there is no error
+- `error`: Any `Error` returned by Firebase when trying to load the data, or `undefined` if there is no error
 
 ### useObject
 
@@ -122,21 +130,24 @@ Retrieve and monitor an object or primitive value in the Firebase Realtime Datab
 
 The `useObject` hook takes the following parameters:
 
-- `reference`: (optional) `firebase.database.Reference` for the data you would like to load
+- `reference`: (optional) `database.Reference` for the data you would like to load
 
 Returns:
 
-- `snapshot`: a `firebase.database.DataSnapshot`, or `undefined` if no reference is supplied
+- `snapshot`: a `database.DataSnapshot`, or `undefined` if no reference is supplied
 - `loading`: a `boolean` to indicate if the data is still being loaded
-- `error`: Any `firebase.FirebaseError` returned by Firebase when trying to load the data, or `undefined` if there is no error
+- `error`: Any `Error` returned by Firebase when trying to load the data, or `undefined` if there is no error
 
 #### Full Example
 
 ```js
+import { ref, getDatabase } from 'firebase/database';
 import { useObject } from 'react-firebase-hooks/database';
 
+const database = getDatabase(firebaseApp);
+
 const DatabaseValue = () => {
-  const [snapshot, loading, error] = useObject(firebase.database().ref('value'));
+  const [snapshot, loading, error] = useObject(ref(database, 'value'));
 
   return (
     <div>
@@ -153,25 +164,25 @@ const DatabaseValue = () => {
 ### useObjectVal
 
 ```js
-const [value, loading, error] = useObjectVal < T > (reference, options);
+const [value, loading, error] = useObjectVal<T> (reference, options);
 ```
 
-As `useObject`, but this hook returns the typed contents of `firebase.database.DataSnapshot.val()`, rather than the the
-`firebase.database.DataSnapshot` itself.
+As `useObject`, but this hook returns the typed contents of `database.DataSnapshot.val()`, rather than the the
+`database.DataSnapshot` itself.
 
 The `useObjectVal` hook takes the following parameters:
 
-- `reference`: (optional) `firebase.database.Reference` for the data you would like to load
+- `reference`: (optional) `database.Reference` for the data you would like to load
 - `options`: (optional) `Object` with the following parameters:
-  - `keyField`: (optional) `string` field name that should be populated with the `firebase.database.DataSnapshot.key` property in the returned value.
-  - `refField`: (optional) `string` field name that should be populated with the `firebase.database.DataSnapshot.ref` property.
-  - `transform`: (optional) a function that receives the raw `firebase.database.DataSnapshot.val()` to allow manual transformation of the data where required by the application. See [`Transforming data`](#transforming-data) below.
+  - `keyField`: (optional) `string` field name that should be populated with the `database.DataSnapshot.key` property in the returned value.
+  - `refField`: (optional) `string` field name that should be populated with the `database.DataSnapshot.ref` property.
+  - `transform`: (optional) a function that receives the raw `database.DataSnapshot.val()` to allow manual transformation of the data where required by the application. See [`Transforming data`](#transforming-data) below.
 
 Returns:
 
 - `value`: a `T`, or `undefined` if no reference is supplied
 - `loading`: a `boolean` to indicate if the data is still being loaded
-- `error`: Any `firebase.FirebaseError` returned by Firebase when trying to load the data, or `undefined` if there is no error
+- `error`: Any `FirebaseError` returned by Firebase when trying to load the data, or `undefined` if there is no error
 
 ## Transforming data
 

--- a/database/helpers/index.ts
+++ b/database/helpers/index.ts
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app';
+import { DataSnapshot } from 'firebase/database';
 
 export type ValOptions<T> = {
   keyField?: string;
@@ -10,7 +10,7 @@ const isObject = (val: any) =>
   val != null && typeof val === 'object' && Array.isArray(val) === false;
 
 export const snapshotToData = <T>(
-  snapshot: firebase.database.DataSnapshot,
+  snapshot: DataSnapshot,
   keyField?: string,
   refField?: string,
   transform?: (val: any) => T

--- a/database/helpers/useListReducer.ts
+++ b/database/helpers/useListReducer.ts
@@ -1,13 +1,13 @@
-import firebase from 'firebase/app';
+import { DataSnapshot } from 'firebase/database';
 import { useReducer } from 'react';
 
 type KeyValueState = {
   keys?: string[];
-  values?: firebase.database.DataSnapshot[];
+  values?: DataSnapshot[];
 };
 
 type ReducerState = {
-  error?: firebase.FirebaseError;
+  error?: Error;
   loading: boolean;
   value: KeyValueState;
 };
@@ -15,25 +15,25 @@ type ReducerState = {
 type AddAction = {
   type: 'add';
   previousKey?: string | null;
-  snapshot: firebase.database.DataSnapshot | null;
+  snapshot: DataSnapshot | null;
 };
 type ChangeAction = {
   type: 'change';
-  snapshot: firebase.database.DataSnapshot | null;
+  snapshot: DataSnapshot | null;
 };
 type EmptyAction = { type: 'empty' };
-type ErrorAction = { type: 'error'; error: firebase.FirebaseError };
+type ErrorAction = { type: 'error'; error: Error };
 type MoveAction = {
   type: 'move';
   previousKey?: string | null;
-  snapshot: firebase.database.DataSnapshot | null;
+  snapshot: DataSnapshot | null;
 };
 type RemoveAction = {
   type: 'remove';
-  snapshot: firebase.database.DataSnapshot | null;
+  snapshot: DataSnapshot | null;
 };
 type ResetAction = { type: 'reset' };
-type ValueAction = { type: 'value'; snapshots: firebase.database.DataSnapshot[] | null };
+type ValueAction = { type: 'value'; snapshots: DataSnapshot[] | null };
 type ReducerAction =
   | AddAction
   | ChangeAction
@@ -126,7 +126,7 @@ const listReducer = (
   }
 };
 
-const setValue = (snapshots: firebase.database.DataSnapshot[] | null): KeyValueState => {
+const setValue = (snapshots: DataSnapshot[] | null): KeyValueState => {
   if (!snapshots) {
     return {
       keys: [],
@@ -135,7 +135,7 @@ const setValue = (snapshots: firebase.database.DataSnapshot[] | null): KeyValueS
   }
 
   const keys: string[] = [];
-  const values: firebase.database.DataSnapshot[] = [];
+  const values: DataSnapshot[] = [];
   snapshots.forEach((snapshot) => {
     if (!snapshot.key) {
       return;
@@ -152,7 +152,7 @@ const setValue = (snapshots: firebase.database.DataSnapshot[] | null): KeyValueS
 
 const addChild = (
   currentState: KeyValueState,
-  snapshot: firebase.database.DataSnapshot,
+  snapshot: DataSnapshot,
   previousKey?: string | null
 ): KeyValueState => {
   if (!snapshot.key) {
@@ -182,7 +182,7 @@ const addChild = (
 
 const changeChild = (
   currentState: KeyValueState,
-  snapshot: firebase.database.DataSnapshot
+  snapshot: DataSnapshot
 ): KeyValueState => {
   if (!snapshot.key) {
     return currentState;
@@ -199,7 +199,7 @@ const changeChild = (
 
 const removeChild = (
   currentState: KeyValueState,
-  snapshot: firebase.database.DataSnapshot
+  snapshot: DataSnapshot
 ): KeyValueState => {
   if (!snapshot.key) {
     return currentState;
@@ -217,7 +217,7 @@ const removeChild = (
 
 const moveChild = (
   currentState: KeyValueState,
-  snapshot: firebase.database.DataSnapshot,
+  snapshot: DataSnapshot,
   previousKey?: string | null
 ): KeyValueState => {
   // Remove the child from it's previous location

--- a/database/index.js.flow
+++ b/database/index.js.flow
@@ -1,8 +1,7 @@
 // @flow
-import typeof { FirebaseError } from 'firebase';
 import type { DataSnapshot, Query } from 'firebase/database';
 
-type LoadingHook<T> = [T | void, boolean, FirebaseError | void];
+type LoadingHook<T> = [T | void, boolean, Error | void];
 
 export type ListHook = LoadingHook<DataSnapshot[]>;
 export type ListKeysHook = LoadingHook<string[]>;

--- a/database/types.ts
+++ b/database/types.ts
@@ -1,31 +1,23 @@
-import firebase from 'firebase/app';
+import { DatabaseReference, DataSnapshot } from 'firebase/database';
 import { LoadingHook } from '../util';
 
 export type Val<
   T,
   KeyField extends string = '',
   RefField extends string = ''
-> = T &
-  Record<KeyField, string> &
-  Record<RefField, firebase.database.Reference>;
+> = T & Record<KeyField, string> & Record<RefField, DatabaseReference>;
 
-export type ObjectHook = LoadingHook<
-  firebase.database.DataSnapshot,
-  firebase.FirebaseError
->;
+export type ObjectHook = LoadingHook<DataSnapshot, Error>;
 export type ObjectValHook<
   T,
   KeyField extends string = '',
   RefField extends string = ''
-> = LoadingHook<Val<T, KeyField, RefField>, firebase.FirebaseError>;
+> = LoadingHook<Val<T, KeyField, RefField>, Error>;
 
-export type ListHook = LoadingHook<
-  firebase.database.DataSnapshot[],
-  firebase.FirebaseError
->;
-export type ListKeysHook = LoadingHook<string[], firebase.FirebaseError>;
+export type ListHook = LoadingHook<DataSnapshot[], Error>;
+export type ListKeysHook = LoadingHook<string[], Error>;
 export type ListValsHook<
   T,
   KeyField extends string = '',
   RefField extends string = ''
-> = LoadingHook<Val<T, KeyField, RefField>[], firebase.FirebaseError>;
+> = LoadingHook<Val<T, KeyField, RefField>[], Error>;

--- a/database/useObject.ts
+++ b/database/useObject.ts
@@ -1,15 +1,13 @@
-import firebase from 'firebase/app';
 import { useEffect, useMemo } from 'react';
 import { snapshotToData, ValOptions } from './helpers';
 import { ObjectHook, ObjectValHook, Val } from './types';
 import { useIsEqualRef, useLoadingValue } from '../util';
+import { DataSnapshot, off, onValue, Query } from 'firebase/database';
 
-export const useObject = (
-  query?: firebase.database.Query | null
-): ObjectHook => {
+export const useObject = (query?: Query | null): ObjectHook => {
   const { error, loading, reset, setError, setValue, value } = useLoadingValue<
-    firebase.database.DataSnapshot,
-    firebase.FirebaseError
+    DataSnapshot,
+    Error
   >();
   const ref = useIsEqualRef(query, reset);
 
@@ -20,10 +18,10 @@ export const useObject = (
       return;
     }
 
-    query.on('value', setValue, setError);
+    onValue(query, setValue, setError);
 
     return () => {
-      query.off('value', setValue);
+      off(query, 'value', setValue);
     };
   }, [ref.current]);
 
@@ -36,7 +34,7 @@ export const useObjectVal = <
   KeyField extends string = '',
   RefField extends string = ''
 >(
-  query?: firebase.database.Query | null,
+  query?: Query | null,
   options?: ValOptions<T>
 ): ObjectValHook<T, KeyField, RefField> => {
   const keyField = options ? options.keyField : undefined;

--- a/firestore/README.md
+++ b/firestore/README.md
@@ -1,10 +1,7 @@
-Temporary package to migrate `react-firebase-hooks` to Firebase v9.
-
 # React Firebase Hooks - Cloud Firestore
 
-React Firebase Hooks provides convenience listeners for Collections and Documents stored with
-Cloud Firestore. The hooks wrap around the `firebase.firestore.collection().onSnapshot()`
-and `firebase.firestore().doc().onSnapshot()` methods.
+React Firebase Hooks provides convenience listeners for Collections and Documents stored with Cloud Firestore. The hooks wrap around the `onSnapshot(collection(...))`
+and `firestore.onSnapshot(firestore.doc(...))` methods.
 
 In addition to returning the snapshot value, the hooks provide an `error` and `loading` property
 to give a complete lifecycle for loading and listening to Cloud Firestore.
@@ -47,28 +44,29 @@ const [snapshot, loading, error] = useCollection(query, options);
 
 Retrieve and monitor a collection value in Cloud Firestore.
 
-Returns a `firebase.firestore.QuerySnapshot` (if a query is specified), a `boolean` to indicate if the data is still being loaded and any `Error` returned by Firebase when trying to load the data.
+Returns a `firestore.QuerySnapshot` (if a query is specified), a `boolean` to indicate if the data is still being loaded and any `firestore.FirestoreError` returned by Firebase when trying to load the data.
 
 The `useCollection` hook takes the following parameters:
 
-- `query`: (optional) `firebase.firestore.Query` for the data you would like to load
+- `query`: (optional) `firestore.Query` for the data you would like to load
 - `options`: (optional) `Object` with the following parameters:
-  - `snapshotListenOptions`: (optional) `firebase.firestore.SnapshotListenOptions` to customise how the query is loaded
+  - `snapshotListenOptions`: (optional) `firestore.SnapshotListenOptions` to customise how the query is loaded
 
 Returns:
 
-- `snapshot`: a `firebase.firestore.QuerySnapshot`, or `undefined` if no query is supplied
+- `snapshot`: a `firestore.QuerySnapshot`, or `undefined` if no query is supplied
 - `loading`: a `boolean` to indicate if the data is still being loaded
-- `error`: Any `Error` returned by Firebase when trying to load the data, or `undefined` if there is no error
+- `error`: Any `firestore.FirestoreError` returned by Firebase when trying to load the data, or `undefined` if there is no error
 
 #### Full example
 
 ```js
+import { getFirestore, collection } from 'firebase/firestore';
 import { useCollection } from 'react-firebase-hooks/firestore';
 
 const FirestoreCollection = () => {
   const [value, loading, error] = useCollection(
-    firebase.firestore().collection('hooks'),
+    collection(getFirestore(firebaseApp), 'hooks'),
     {
       snapshotListenOptions: { includeMetadataChanges: true },
     }
@@ -100,68 +98,70 @@ const FirestoreCollection = () => {
 const [snapshot, loading, error] = useCollectionOnce(query, options);
 ```
 
-Retrieve the current value of the `firebase.firestore.Query`.
+Retrieve the current value of the `firestore.Query`.
 
 The `useCollectionOnce` hook takes the following parameters:
 
-- `query`: (optional) `firebase.firestore.Query` for the data you would like to load
+- `query`: (optional) `firestore.Query` for the data you would like to load
 - `options`: (optional) `Object` with the following parameters:
-  - `getOptions`: (optional) `firebase.firestore.GetOptions` to customise how the collection is loaded
+  - `getOptions`: (optional) `Object` to customise how the collection is loaded
+    - `source`: (optional): `'default' | 'server' | 'cache'` Describes whether we should get from server or cache.
 
 Returns:
 
-- `snapshot`: a `firebase.firestore.QuerySnapshot`, or `undefined` if no query is supplied
+- `snapshot`: a `firestore.QuerySnapshot`, or `undefined` if no query is supplied
 - `loading`: a `boolean` to indicate if the data is still being loaded
-- `error`: Any `Error` returned by Firebase when trying to load the data, or `undefined` if there is no error
+- `error`: Any `firestore.FirestoreError` returned by Firebase when trying to load the data, or `undefined` if there is no error
 
 ### useCollectionData
 
 ```js
-const [values, loading, error] = useCollectionData < T > (query, options);
+const [values, loading, error] = useCollectionData<T> (query, options);
 ```
 
-As `useCollection`, but this hook extracts a typed list of the `firebase.firestore.QuerySnapshot.docs` values, rather than the
-`firebase.firestore.QuerySnapshot` itself.
+As `useCollection`, but this hook extracts a typed list of the `firestore.QuerySnapshot.docs` values, rather than the
+`firestore.QuerySnapshot` itself.
 
 The `useCollectionData` hook takes the following parameters:
 
-- `query`: (optional) `firebase.firestore.Query` for the data you would like to load
+- `query`: (optional) `firestore.Query` for the data you would like to load
 - `options`: (optional) `Object` with the following parameters:
-  - `idField`: (optional) name of the field that should be populated with the `firebase.firestore.QuerySnapshot.id` property.
-  - `refField`: (optional) name of the field that should be populated with the `firebase.firestore.QuerySnapshot.ref` property.
-  - `snapshotListenOptions`: (optional) `firebase.firestore.SnapshotListenOptions` to customise how the collection is loaded
-  - `snapshotOptions`: (optional) `firebase.firestore.SnapshotOptions` to customise how data is retrieved from snapshots
-  - `transform`: (optional) a function that receives the raw `firebase.firestore.DocumentData` for each item in the collection to allow manual transformation of the data where required by the application. See [`Transforming data`](#transforming-data) below.
+  - `idField`: (optional) name of the field that should be populated with the `firestore.QuerySnapshot.id` property.
+  - `refField`: (optional) name of the field that should be populated with the `firestore.QuerySnapshot.ref` property.
+  - `snapshotListenOptions`: (optional) `firestore.SnapshotListenOptions` to customise how the collection is loaded
+  - `snapshotOptions`: (optional) `firestore.SnapshotOptions` to customise how data is retrieved from snapshots
+  - `transform`: (optional) a function that receives the raw `firestore.DocumentData` for each item in the collection to allow manual transformation of the data where required by the application. See [`Transforming data`](#transforming-data) below.
 
 Returns:
 
 - `values`: an array of `T`, or `undefined` if no query is supplied
 - `loading`: a `boolean` to indicate if the data is still being loaded
-- `error`: Any `Error` returned by Firebase when trying to load the data, or `undefined` if there is no error
+- `error`: Any `firestore.FirestoreError` returned by Firebase when trying to load the data, or `undefined` if there is no error
 
 ### useCollectionDataOnce
 
 ```js
-const [values, loading, error] = useCollectionDataOnce < T > (query, options);
+const [values, loading, error] = useCollectionDataOnce<T>(query, options);
 ```
 
-As `useCollectionData`, but this hook will only read the current value of the `firebase.firestore.Query`.
+As `useCollectionData`, but this hook will only read the current value of the `firestore.Query`.
 
 The `useCollectionDataOnce` hook takes the following parameters:
 
-- `query`: (optional) `firebase.firestore.Query` for the data you would like to load
+- `query`: (optional) `firestore.Query` for the data you would like to load
 - `options`: (optional) `Object` with the following parameters:
-  - `getOptions`: (optional) `firebase.firestore.GetOptions` to customise how the collection is loaded
-  - `idField`: (optional) name of the field that should be populated with the `firebase.firestore.QuerySnapshot.id` property.
-  - `refField`: (optional) name of the field that should be populated with the `firebase.firestore.QuerySnapshot.ref` property.
-  - `snapshotOptions`: (optional) `firebase.firestore.SnapshotOptions` to customise how data is retrieved from snapshots
-  - `transform`: (optional) a function that receives the raw `firebase.firestore.DocumentData` for each item in the collection to allow manual transformation of the data where required by the application. See [`Transforming data`](#transforming-data) below.
+  - `getOptions`: (optional) `Object` to customise how the collection is loaded
+    - `source`: (optional): `'default' | 'server' | 'cache'` Describes whether we should get from server or cache.
+  - `idField`: (optional) name of the field that should be populated with the `firestore.QuerySnapshot.id` property.
+  - `refField`: (optional) name of the field that should be populated with the `firestore.QuerySnapshot.ref` property.
+  - `snapshotOptions`: (optional) `firestore.SnapshotOptions` to customise how data is retrieved from snapshots
+  - `transform`: (optional) a function that receives the raw `firestore.DocumentData` for each item in the collection to allow manual transformation of the data where required by the application. See [`Transforming data`](#transforming-data) below.
 
 Returns:
 
 - `values`: an array of `T`, or `undefined` if no query is supplied
 - `loading`: a `boolean` to indicate if the data is still being loaded
-- `error`: Any `Error` returned by Firebase when trying to load the data, or `undefined` if there is no error
+- `error`: Any `firestore.FirestoreError` returned by Firebase when trying to load the data, or `undefined` if there is no error
 
 ### useDocument
 
@@ -173,24 +173,25 @@ Retrieve and monitor a document value in Cloud Firestore.
 
 The `useDocument` hook takes the following parameters:
 
-- `reference`: (optional) `firebase.firestore.DocumentReference` for the data you would like to load
+- `reference`: (optional) `firestore.DocumentReference` for the data you would like to load
 - `options`: (optional) `Object` with the following parameters:
-  - `snapshotListenOptions`: (optional) `firebase.firestore.SnapshotListenOptions` to customise how the query is loaded
+  - `snapshotListenOptions`: (optional) `firestore.SnapshotListenOptions` to customise how the query is loaded
 
 Returns:
 
-- `snapshot`: a `firebase.firestore.DocumentSnapshot`, or `undefined` if no query is supplied
+- `snapshot`: a `firestore.DocumentSnapshot`, or `undefined` if no query is supplied
 - `loading`: a `boolean` to indicate if the data is still being loaded
-- `error`: Any `Error` returned by Firebase when trying to load the data, or `undefined` if there is no error
+- `error`: Any `firestore.FirestoreError` returned by Firebase when trying to load the data, or `undefined` if there is no error
 
 #### Full example
 
 ```js
+import { getFirestore, doc } from 'firebase/firestore';
 import { useDocument } from 'react-firebase-hooks/firestore';
 
 const FirestoreDocument = () => {
   const [value, loading, error] = useDocument(
-    firebase.firestore().doc('hooks/nBShXiRGFAhuiPfBaGpt'),
+    doc(getFirestore(firebaseApp, 'hooks', 'nBShXiRGFAhuiPfBaGpt')),
     {
       snapshotListenOptions: { includeMetadataChanges: true },
     }
@@ -213,68 +214,70 @@ const FirestoreDocument = () => {
 const [snapshot, loading, error] = useDocumentOnce(reference, options);
 ```
 
-Retrieve the current value of the `firebase.firestore.DocumentReference`.
+Retrieve the current value of the `firestore.DocumentReference`.
 
 The `useDocumentOnce` hook takes the following parameters:
 
-- `reference`: (optional) `firebase.firestore.DocumentReference` for the data you would like to load
+- `reference`: (optional) `firestore.DocumentReference` for the data you would like to load
 - `options`: (optional) `Object` with the following parameters:
-  - `getOptions`: (optional) `firebase.firestore.GetOptions` to customise how the collection is loaded
+  - `getOptions`: (optional) `Object` to customise how the collection is loaded
+    - `source`: (optional): `'default' | 'server' | 'cache'` Describes whether we should get from server or cache.
 
 Returns:
 
-- `snapshot`: a `firebase.firestore.DocumentSnapshot`, or `undefined` if no reference is supplied
+- `snapshot`: a `firestore.DocumentSnapshot`, or `undefined` if no reference is supplied
 - `loading`: a `boolean` to indicate if the data is still being loaded
-- `error`: Any `Error` returned by Firebase when trying to load the data, or `undefined` if there is no error
+- `error`: Any `firestore.FirestoreError` returned by Firebase when trying to load the data, or `undefined` if there is no error
 
 ### useDocumentData
 
 ```js
-const [value, loading, error] = useDocumentData < T > (reference, options);
+const [value, loading, error] = useDocumentData<T>(reference, options);
 ```
 
-As `useDocument`, but this hook extracts the typed contents of `firebase.firestore.DocumentSnapshot.val()`, rather than the
-`firebase.firestore.DocumentSnapshot` itself.
+As `useDocument`, but this hook extracts the typed contents of `firestore.DocumentSnapshot.data()`, rather than the
+`firestore.DocumentSnapshot` itself.
 
 The `useDocumentData` hook takes the following parameters:
 
-- `reference`: (optional) `firebase.firestore.DocumentReference` for the data you would like to load
+- `reference`: (optional) `firestore.DocumentReference` for the data you would like to load
 - `options`: (optional) `Object` with the following parameters:
-  - `idField`: (optional) name of the field that should be populated with the `firebase.firestore.DocumentSnapshot.id` property.
-  - `refField`: (optional) name of the field that should be populated with the `firebase.firestore.QuerySnapshot.ref` property.
-  - `snapshotListenOptions`: (optional) `firebase.firestore.SnapshotListenOptions` to customise how the collection is loaded
-  - `snapshotOptions`: (optional) `firebase.firestore.SnapshotOptions` to customise how data is retrieved from snapshots
-  - `transform`: (optional) a function that receives the raw `firebase.firestore.DocumentData` to allow manual transformation of the data where required by the application. See [`Transforming data`](#transforming-data) below.
+  - `idField`: (optional) name of the field that should be populated with the `firestore.DocumentSnapshot.id` property.
+  - `refField`: (optional) name of the field that should be populated with the `firestore.QuerySnapshot.ref` property.
+  - `snapshotListenOptions`: (optional) `firestore.SnapshotListenOptions` to customise how the collection is loaded
+  - `snapshotOptions`: (optional) `firestore.SnapshotOptions` to customise how data is retrieved from snapshots
+  - `transform`: (optional) a function that receives the raw `firestore.DocumentData` to allow manual transformation of the data where required by the application. See [`Transforming data`](#transforming-data) below.
 
 Returns:
 
 - `value`: `T`, or `undefined` if no query is supplied
 - `loading`: a `boolean` to indicate if the data is still being loaded
-- `error`: Any `Error` returned by Firebase when trying to load the data, or `undefined` if there is no error
+- `error`: Any `firestore.FirestoreError` returned by Firebase when trying to load the data, or `undefined` if there is no error
 
 ### useDocumentDataOnce
 
 ```js
-const [value, loading, error] = useDocumentDataOnce < T > (reference, options);
+const [value, loading, error] = useDocumentDataOnce<T> (reference, options);
 ```
 
-As `useDocument`, but this hook will only read the current value of the `firebase.firestore.DocumentReference`.
+As `useDocument`, but this hook will only read the current value of the `firestore.DocumentReference`.
 
 The `useDocumentDataOnce` hook takes the following parameters:
 
-- `reference`: (optional) `firebase.firestore.DocumentReference` for the data you would like to load
+- `reference`: (optional) `firestore.DocumentReference` for the data you would like to load
 - `options`: (optional) `Object` with the following parameters:
-  - `getOptions`: (optional) `firebase.firestore.GetOptions` to customise how the collection is loaded
-  - `idField`: (optional) name of the field that should be populated with the `firebase.firestore.DocumentSnapshot.id` property.
-  - `refField`: (optional) name of the field that should be populated with the `firebase.firestore.QuerySnapshot.ref` property.
-  - `snapshotOptions`: (optional) `firebase.firestore.SnapshotOptions` to customise how data is retrieved from snapshots
-  - `transform`: (optional) a function that receives the raw `firebase.firestore.DocumentData` to allow manual transformation of the data where required by the application. See [`Transforming data`](#transforming-data) below.
+  - `getOptions`: (optional) `Object` to customise how the collection is loaded
+    - `source`: (optional): `'default' | 'server' | 'cache'` Describes whether we should get from server or cache.
+  - `idField`: (optional) name of the field that should be populated with the `firestore.DocumentSnapshot.id` property.
+  - `refField`: (optional) name of the field that should be populated with the `firestore.QuerySnapshot.ref` property.
+  - `snapshotOptions`: (optional) `firestore.SnapshotOptions` to customise how data is retrieved from snapshots
+  - `transform`: (optional) a function that receives the raw `firestore.DocumentData` to allow manual transformation of the data where required by the application. See [`Transforming data`](#transforming-data) below.
 
 Returns:
 
 - `value`: `T`, or `undefined` if no query is supplied
 - `loading`: a `boolean` to indicate if the data is still being loaded
-- `error`: Any `Error` returned by Firebase when trying to load the data, or `undefined` if there is no error
+- `error`: Any `firestore.FirestoreError` returned by Firebase when trying to load the data, or `undefined` if there is no error
 
 ## Transforming data
 

--- a/firestore/README.md
+++ b/firestore/README.md
@@ -1,3 +1,5 @@
+Temporary package to migrate `react-firebase-hooks` to Firebase v9.
+
 # React Firebase Hooks - Cloud Firestore
 
 React Firebase Hooks provides convenience listeners for Collections and Documents stored with
@@ -20,14 +22,18 @@ import { useCollection } from 'react-firebase-hooks/firestore';
 
 List of Cloud Firestore hooks:
 
-- [useCollection](#usecollection)
-- [useCollectionOnce](#usecollectiononce)
-- [useCollectionData](#usecollectiondata)
-- [useCollectionDataOnce](#usecollectiondataonce)
-- [useDocument](#usedocument)
-- [useDocumentOnce](#usedocumentonce)
-- [useDocumentData](#usedocumentdata)
-- [useDocumentDataOnce](#usedocumentdataonce)
+- [React Firebase Hooks - Cloud Firestore](#react-firebase-hooks---cloud-firestore)
+    - [useCollection](#usecollection)
+      - [Full example](#full-example)
+    - [useCollectionOnce](#usecollectiononce)
+    - [useCollectionData](#usecollectiondata)
+    - [useCollectionDataOnce](#usecollectiondataonce)
+    - [useDocument](#usedocument)
+      - [Full example](#full-example-1)
+    - [useDocumentOnce](#usedocumentonce)
+    - [useDocumentData](#usedocumentdata)
+    - [useDocumentDataOnce](#usedocumentdataonce)
+  - [Transforming data](#transforming-data)
 
 Additional functionality:
 

--- a/firestore/helpers/index.ts
+++ b/firestore/helpers/index.ts
@@ -5,7 +5,7 @@ import {
 } from 'firebase/firestore';
 
 export const snapshotToData = <T = DocumentData>(
-  snapshot: DocumentSnapshot,
+  snapshot: DocumentSnapshot<T>,
   snapshotOptions?: SnapshotOptions,
   idField?: string,
   refField?: string,

--- a/firestore/helpers/index.ts
+++ b/firestore/helpers/index.ts
@@ -1,8 +1,12 @@
-import firebase from 'firebase/app';
+import {
+  DocumentData,
+  DocumentSnapshot,
+  SnapshotOptions,
+} from 'firebase/firestore';
 
-export const snapshotToData = <T = firebase.firestore.DocumentData>(
-  snapshot: firebase.firestore.DocumentSnapshot,
-  snapshotOptions?: firebase.firestore.SnapshotOptions,
+export const snapshotToData = <T = DocumentData>(
+  snapshot: DocumentSnapshot,
+  snapshotOptions?: SnapshotOptions,
   idField?: string,
   refField?: string,
   transform?: (val: any) => T
@@ -11,7 +15,7 @@ export const snapshotToData = <T = firebase.firestore.DocumentData>(
     return undefined;
   }
 
-  let data = snapshot.data(snapshotOptions) as firebase.firestore.DocumentData;
+  let data = snapshot.data(snapshotOptions) as DocumentData;
   if (transform) {
     data = transform(data);
   }

--- a/firestore/index.js.flow
+++ b/firestore/index.js.flow
@@ -2,7 +2,6 @@
 import type {
   DocumentReference,
   DocumentSnapshot,
-  GetOptions,
   Query,
   QuerySnapshot,
   SnapshotListenOptions,
@@ -10,6 +9,9 @@ import type {
 
 type LoadingHook<T> = [T | void, boolean, Error | void];
 
+export type GetOptions = {
+  source?: 'default' | 'server' | 'cache';
+};
 export type CollectionHook = LoadingHook<QuerySnapshot>;
 export type CollectionDataHook<T> = LoadingHook<T[]>;
 export type DocumentHook = LoadingHook<DocumentSnapshot>;

--- a/firestore/types.ts
+++ b/firestore/types.ts
@@ -1,44 +1,53 @@
-import firebase from 'firebase/app';
+import {
+  DocumentData,
+  DocumentReference,
+  DocumentSnapshot,
+  FirestoreError,
+  QuerySnapshot,
+  SnapshotListenOptions,
+  SnapshotOptions,
+} from 'firebase/firestore';
 import { LoadingHook } from '../util';
 
 export type IDOptions<T> = {
   idField?: string;
   refField?: string;
-  snapshotOptions?: firebase.firestore.SnapshotOptions;
+  snapshotOptions?: SnapshotOptions;
   transform?: (val: any) => T;
 };
 export type Options = {
-  snapshotListenOptions?: firebase.firestore.SnapshotListenOptions;
+  snapshotListenOptions?: SnapshotListenOptions;
 };
 export type DataOptions<T> = Options & IDOptions<T>;
 export type OnceOptions = {
-  getOptions?: firebase.firestore.GetOptions;
+  getOptions?: GetOptions;
+};
+export type GetOptions = {
+  source?: 'default' | 'server' | 'cache';
 };
 export type OnceDataOptions<T> = OnceOptions & IDOptions<T>;
 export type Data<
-  T = firebase.firestore.DocumentData,
+  T = DocumentData,
   IDField extends string = '',
   RefField extends string = ''
-> = T &
-  Record<IDField, string> &
-  Record<RefField, firebase.firestore.DocumentReference<T>>;
+> = T & Record<IDField, string> & Record<RefField, DocumentReference<T>>;
 
-export type CollectionHook<T = firebase.firestore.DocumentData> = LoadingHook<
-  firebase.firestore.QuerySnapshot<T>,
-  firebase.FirebaseError
+export type CollectionHook<T = DocumentData> = LoadingHook<
+  QuerySnapshot<T>,
+  FirestoreError
 >;
 export type CollectionDataHook<
-  T = firebase.firestore.DocumentData,
+  T = DocumentData,
   IDField extends string = '',
   RefField extends string = ''
-> = LoadingHook<Data<T, IDField, RefField>[], firebase.FirebaseError>;
+> = LoadingHook<Data<T, IDField, RefField>[], FirestoreError>;
 
-export type DocumentHook<T = firebase.firestore.DocumentData> = LoadingHook<
-  firebase.firestore.DocumentSnapshot<T>,
-  firebase.FirebaseError
+export type DocumentHook<T = DocumentData> = LoadingHook<
+  DocumentSnapshot<T>,
+  FirestoreError
 >;
 export type DocumentDataHook<
-  T = firebase.firestore.DocumentData,
+  T = DocumentData,
   IDField extends string = '',
   RefField extends string = ''
-> = LoadingHook<Data<T, IDField, RefField>, firebase.FirebaseError>;
+> = LoadingHook<Data<T, IDField, RefField>, FirestoreError>;

--- a/firestore/useCollection.ts
+++ b/firestore/useCollection.ts
@@ -90,7 +90,7 @@ const useCollectionInternal = <T = DocumentData>(
         listener();
       };
     } else {
-      const get = getDocsFnFromGetOptions(options?.getOptions);
+      const get = getDocsFnFromGetOptions(options ? options.getOptions : undefined);
       get(ref.current).then(setValue).catch(setError);
     }
   }, [ref.current]);

--- a/firestore/useCollection.ts
+++ b/firestore/useCollection.ts
@@ -65,7 +65,7 @@ const useCollectionInternal = <T = DocumentData>(
   options?: Options & OnceOptions
 ) => {
   const { error, loading, reset, setError, setValue, value } = useLoadingValue<
-    QuerySnapshot,
+    QuerySnapshot<T>,
     FirestoreError
   >();
   const ref = useIsEqualFirestoreQuery<Query<T>>(query, reset);

--- a/firestore/useCollection.ts
+++ b/firestore/useCollection.ts
@@ -1,63 +1,74 @@
-import firebase from 'firebase/app';
+import {
+  DocumentData,
+  FirestoreError,
+  getDocs,
+  getDocsFromCache,
+  getDocsFromServer,
+  onSnapshot,
+  Query,
+  QuerySnapshot,
+} from 'firebase/firestore';
 import { useEffect, useMemo } from 'react';
+import { useLoadingValue } from '../util';
 import { snapshotToData } from './helpers';
 import {
-  CollectionHook,
   CollectionDataHook,
+  CollectionHook,
   Data,
   DataOptions,
-  OnceOptions,
+  GetOptions,
   OnceDataOptions,
+  OnceOptions,
   Options,
 } from './types';
-import { useIsEqualRef, useLoadingValue } from '../util';
+import { useIsEqualFirestoreQuery } from './util';
 
-export const useCollection = <T = firebase.firestore.DocumentData>(
-  query?: firebase.firestore.Query | null,
+export const useCollection = <T = DocumentData>(
+  query?: Query<T> | null,
   options?: Options
 ): CollectionHook<T> => {
   return useCollectionInternal<T>(true, query, options);
 };
 
-export const useCollectionOnce = <T = firebase.firestore.DocumentData>(
-  query?: firebase.firestore.Query<T> | null,
+export const useCollectionOnce = <T = DocumentData>(
+  query?: Query<T> | null,
   options?: OnceOptions
 ): CollectionHook<T> => {
   return useCollectionInternal<T>(false, query, options);
 };
 
 export const useCollectionData = <
-  T = firebase.firestore.DocumentData,
+  T = DocumentData,
   IDField extends string = '',
   RefField extends string = ''
 >(
-  query?: firebase.firestore.Query | null,
+  query?: Query<T> | null,
   options?: DataOptions<T>
 ): CollectionDataHook<T, IDField, RefField> => {
   return useCollectionDataInternal<T, IDField, RefField>(true, query, options);
 };
 
 export const useCollectionDataOnce = <
-  T = firebase.firestore.DocumentData,
+  T = DocumentData,
   IDField extends string = '',
   RefField extends string = ''
 >(
-  query?: firebase.firestore.Query | null,
+  query?: Query<T> | null,
   options?: OnceDataOptions<T>
 ): CollectionDataHook<T, IDField, RefField> => {
   return useCollectionDataInternal<T, IDField, RefField>(false, query, options);
 };
 
-const useCollectionInternal = <T = firebase.firestore.DocumentData>(
+const useCollectionInternal = <T = DocumentData>(
   listen: boolean,
-  query?: firebase.firestore.Query | null,
+  query?: Query<T> | null,
   options?: Options & OnceOptions
 ) => {
   const { error, loading, reset, setError, setValue, value } = useLoadingValue<
-    firebase.firestore.QuerySnapshot,
-    firebase.FirebaseError
+    QuerySnapshot,
+    FirestoreError
   >();
-  const ref = useIsEqualRef(query, reset);
+  const ref = useIsEqualFirestoreQuery<Query<T>>(query, reset);
 
   useEffect(() => {
     if (!ref.current) {
@@ -67,26 +78,25 @@ const useCollectionInternal = <T = firebase.firestore.DocumentData>(
     if (listen) {
       const listener =
         options && options.snapshotListenOptions
-          ? ref.current.onSnapshot(
+          ? onSnapshot(
+              ref.current,
               options.snapshotListenOptions,
               setValue,
               setError
             )
-          : ref.current.onSnapshot(setValue, setError);
+          : onSnapshot(ref.current, setValue, setError);
 
       return () => {
         listener();
       };
     } else {
-      ref.current
-        .get(options ? options.getOptions : undefined)
-        .then(setValue)
-        .catch(setError);
+      const get = getDocsFnFromGetOptions(options?.getOptions);
+      get(ref.current).then(setValue).catch(setError);
     }
   }, [ref.current]);
 
   const resArray: CollectionHook<T> = [
-    value as firebase.firestore.QuerySnapshot<T>,
+    value as QuerySnapshot<T>,
     loading,
     error,
   ];
@@ -94,12 +104,12 @@ const useCollectionInternal = <T = firebase.firestore.DocumentData>(
 };
 
 const useCollectionDataInternal = <
-  T = firebase.firestore.DocumentData,
+  T = DocumentData,
   IDField extends string = '',
   RefField extends string = ''
 >(
   listen: boolean,
-  query?: firebase.firestore.Query | null,
+  query?: Query<T> | null,
   options?: DataOptions<T> & OnceDataOptions<T>
 ): CollectionDataHook<T, IDField, RefField> => {
   const idField = options ? options.idField : undefined;
@@ -134,3 +144,17 @@ const useCollectionDataInternal = <
   ];
   return useMemo(() => resArray, resArray);
 };
+
+function getDocsFnFromGetOptions(
+  { source }: GetOptions = { source: 'default' }
+) {
+  switch (source) {
+    default:
+    case 'default':
+      return getDocs;
+    case 'cache':
+      return getDocsFromCache;
+    case 'server':
+      return getDocsFromServer;
+  }
+}

--- a/firestore/useDocument.ts
+++ b/firestore/useDocument.ts
@@ -90,7 +90,9 @@ const useDocumentInternal = <T = DocumentData>(
         listener();
       };
     } else {
-      const get = getDocFnFromGetOptions(options?.getOptions);
+      const get = getDocFnFromGetOptions(
+        options ? options.getOptions : undefined
+      );
 
       get(ref.current).then(setValue).catch(setError);
     }

--- a/firestore/util.ts
+++ b/firestore/util.ts
@@ -1,0 +1,44 @@
+import {
+  CollectionReference,
+  DocumentReference,
+  Query,
+  queryEqual,
+  refEqual,
+} from 'firebase/firestore';
+import { RefHook, useComparatorRef } from '../util';
+
+const isRefEqual = <
+  T extends DocumentReference<unknown> | CollectionReference<unknown>
+>(
+  v1: T | null | undefined,
+  v2: T | null | undefined
+): boolean => {
+  const bothNull: boolean = !v1 && !v2;
+  const equal: boolean = !!v1 && !!v2 && refEqual(v1, v2);
+  return bothNull || equal;
+};
+
+export const useIsEqualFirestoreRef = <
+  T extends DocumentReference<unknown> | CollectionReference<unknown>
+>(
+  value: T | null | undefined,
+  onChange?: () => void
+): RefHook<T | null | undefined> => {
+  return useComparatorRef(value, isRefEqual, onChange);
+};
+
+const isQueryEqual = <T extends Query<unknown>>(
+  v1: T | null | undefined,
+  v2: T | null | undefined
+): boolean => {
+  const bothNull: boolean = !v1 && !v2;
+  const equal: boolean = !!v1 && !!v2 && queryEqual(v1, v2);
+  return bothNull || equal;
+};
+
+export const useIsEqualFirestoreQuery = <T extends Query<unknown>>(
+  value: T | null | undefined,
+  onChange?: () => void
+): RefHook<T | null | undefined> => {
+  return useComparatorRef(value, isQueryEqual, onChange);
+};

--- a/firestore/util.ts
+++ b/firestore/util.ts
@@ -8,7 +8,7 @@ import {
 import { RefHook, useComparatorRef } from '../util';
 
 const isRefEqual = <
-  T extends DocumentReference<unknown> | CollectionReference<unknown>
+  T extends DocumentReference<any> | CollectionReference<any>
 >(
   v1: T | null | undefined,
   v2: T | null | undefined
@@ -19,7 +19,7 @@ const isRefEqual = <
 };
 
 export const useIsEqualFirestoreRef = <
-  T extends DocumentReference<unknown> | CollectionReference<unknown>
+  T extends DocumentReference<any> | CollectionReference<any>
 >(
   value: T | null | undefined,
   onChange?: () => void
@@ -27,7 +27,7 @@ export const useIsEqualFirestoreRef = <
   return useComparatorRef(value, isRefEqual, onChange);
 };
 
-const isQueryEqual = <T extends Query<unknown>>(
+const isQueryEqual = <T extends Query<any>>(
   v1: T | null | undefined,
   v2: T | null | undefined
 ): boolean => {
@@ -36,7 +36,7 @@ const isQueryEqual = <T extends Query<unknown>>(
   return bothNull || equal;
 };
 
-export const useIsEqualFirestoreQuery = <T extends Query<unknown>>(
+export const useIsEqualFirestoreQuery = <T extends Query<any>>(
   value: T | null | undefined,
   onChange?: () => void
 ): RefHook<T | null | undefined> => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,282 +1,2405 @@
 {
   "name": "react-firebase-hooks",
   "version": "3.0.4",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "react-firebase-hooks",
+      "version": "3.0.4",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/react": "^17.0.0",
+        "firebase": "9.1.0",
+        "path": "^0.12.7",
+        "prettier": "2.2.1",
+        "react": "^17.0.1",
+        "rimraf": "^2.6.2",
+        "rollup": "0.57.1",
+        "rollup-plugin-commonjs": "9.1.0",
+        "rollup-plugin-copy": "^0.2.3",
+        "rollup-plugin-node-resolve": "3.3.0",
+        "rollup-plugin-typescript2": "0.12.0",
+        "rollup-plugin-uglify": "3.0.0",
+        "typescript": "2.8.1"
+      },
+      "peerDependencies": {
+        "firebase": ">= 9.0.0",
+        "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.7.1.tgz",
+      "integrity": "sha512-fTUN47UK4obzIJwmgLMJU46dWZ7pzitCEO+80pQZC7mdLlVs/NW0+tMf6rETwMpKjGSgb25cKidpgEuioQtT7w==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/installations": "0.5.1",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.1.2.tgz",
+      "integrity": "sha512-TpWpz0s8EgVt9aqyOCFktONqVkjyrNRR4esn3cEYrueH+XXSMDLWY9oFHuUJzntcoEOlOBWMvpsJCPG/1kthkg==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/analytics": "0.7.1",
+        "@firebase/analytics-types": "0.7.0",
+        "@firebase/component": "0.5.7",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.7.0.tgz",
+      "integrity": "sha512-DNE2Waiwy5+zZnCfintkDtBfaW6MjIG883474v6Z0K1XZIvl76cLND4iv0YUb48leyF+PJK1KO2XrgHb/KpmhQ==",
+      "dev": true
+    },
+    "node_modules/@firebase/analytics/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.1.tgz",
+      "integrity": "sha512-B4z6E1EPQc0mOjF35IPKdDRCFnT/fNQIHfM+v7F9obB7ItPhGILK3LxaQfuampSQpF6GG6TPFDbrWK6myXAq+g==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.4.1.tgz",
+      "integrity": "sha512-Kpqh0Y2zpx+acTL7eOVYIWBOmAwoconJpqOAlByGNXuxm/ccP00XREo+HsqaC7wapZRXh+h8BK0jZjvdV36qow==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.1.2.tgz",
+      "integrity": "sha512-JB+OHk4Cp9ZgT+UfX0A+lwH1AoM5Y2X1rDhmhCsEXcKKwz1w9DpL9PjStciP8UYg1dpqbp5p9OMxmty+21EBsA==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/app-check": "0.4.1",
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.1.0.tgz",
+      "integrity": "sha512-uZfn9s4uuRsaX5Lwx+gFP3B6YsyOKUE+Rqa6z9ojT4VSRAsZFko9FRn6OxQUA1z5t5d08fY4pf+/+Dkd5wbdbA==",
+      "dev": true
+    },
+    "node_modules/@firebase/app-check/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.2.tgz",
+      "integrity": "sha512-kF1maoqA8bZqJ4v/ojVvA7kIyyXEPkJmL48otGrC8LIgdcen7xCx3JFDe0DGeQywg+qujvdkJz/TptFN1cvAgw==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/app": "0.7.1",
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-compat/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.7.0.tgz",
+      "integrity": "sha512-6fbHQwDv2jp/v6bXhBw2eSRbNBpxHcd1NBF864UksSMVIqIyri9qpJB1Mn6sGZE+bnDsSQBC5j2TbMxYsJQkQg==",
+      "dev": true
+    },
+    "node_modules/@firebase/app/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/auth": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.18.0.tgz",
+      "integrity": "sha512-iK+VXkdDkum8SmJNgz9ZcOboRLrUN1VW7AHHkpZb76VJvoYRoCPD+A9O/v/ziI0LpwIZJwi1GFes9XjZTlfLiA==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "node-fetch": "2.6.2",
+        "selenium-webdriver": "4.0.0-rc-1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.1.3.tgz",
+      "integrity": "sha512-eDDtY5If+ERJxalt+plvX6avZspuwo4/kPXssvV+csm414awhDzQBtSDPDajgbH3YB9V+O3LAFHeWcP3rrHS5w==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/auth": "0.18.0",
+        "@firebase/auth-types": "0.11.0",
+        "@firebase/component": "0.5.7",
+        "@firebase/util": "1.4.0",
+        "node-fetch": "2.6.2",
+        "selenium-webdriver": "^4.0.0-beta.2",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-compat/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
+      "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==",
+      "dev": true,
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.11.0.tgz",
+      "integrity": "sha512-q7Bt6cx+ySj9elQHTsKulwk3+qDezhzRBFC9zlQ1BjgMueUOnGMcvqmU0zuKlQ4RhLSH7MNAdBV2znVaoN3Vxw==",
+      "dev": true,
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/auth/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.7.tgz",
+      "integrity": "sha512-CiAHUPXh2hn/lpzMShNmfAxHNQhKQwmQUJSYMPCjf2bCCt4Z2vLGpS+UWEuNFm9Zf8LNmkS+Z+U/s4Obi5carg==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/component/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/database": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.12.1.tgz",
+      "integrity": "sha512-Ethk0hc476qnkSKNBa+8Yc7iM8AO69HYWsaD+QUC983FZtnuMyNLHtEeSUbLQYvyHo7cOjcc52slop14WmfZeQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.1.6",
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.1.1.tgz",
+      "integrity": "sha512-K3DFWiw0YkLZtlfA9TOGPw6zVXKu5dQ1XqIGztUufFVRYW8IizReXVxzSSmJNR4Adr2LiU9j66Wenc6e5UfwaQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/database": "0.12.1",
+        "@firebase/database-types": "0.9.1",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/database-compat/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.1.tgz",
+      "integrity": "sha512-RUixK/YrbpxbfdE+nYP0wMcEsz1xPTnafP0q3UlSS/+fW744OITKtR1J0cMRaXbvY7EH0wUVTNVkrtgxYY8IgQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/app-types": "0.7.0",
+        "@firebase/util": "1.4.0"
+      }
+    },
+    "node_modules/@firebase/database/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-3.1.0.tgz",
+      "integrity": "sha512-vOXueHNRjlgBlKVCWuUDhr3dQW2hJwbcqcJaFiIV9V+PamfyhOHzX8pEQkrPort4YQQvoRmY9uiFhfOGj2hbeA==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "@firebase/webchannel-wrapper": "0.6.0",
+        "@grpc/grpc-js": "^1.3.2",
+        "@grpc/proto-loader": "^0.6.0",
+        "node-fetch": "2.6.2",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.1.3.tgz",
+      "integrity": "sha512-tO3uAkIguKeFeKPu99GR7F7v1/Hc8nV1h7B1kdpkVRRBe+NfVYA3qAUictQ3OAA0oy7Ae9z4SfEURO/R1b6YlQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/firestore": "3.1.0",
+        "@firebase/firestore-types": "2.5.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.5.0.tgz",
+      "integrity": "sha512-I6c2m1zUhZ5SH0cWPmINabDyH5w0PPFHk2UHsjBpKdZllzJZ2TwTkXbDtpHUZNmnc/zAa0WNMNMvcvbb/xJLKA==",
+      "dev": true,
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/firestore/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.7.2.tgz",
+      "integrity": "sha512-B+b57xXtpsRYD3UgVtteeyavXjXfBTtuv+sG8LA0vgJs6bhORswVlKZQqpfW9SDxCMBwzzytzn1m3ZZGfUw2Lg==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.1.0",
+        "@firebase/auth-interop-types": "0.1.6",
+        "@firebase/component": "0.5.7",
+        "@firebase/messaging-interop-types": "0.1.0",
+        "@firebase/util": "1.4.0",
+        "node-fetch": "2.6.2",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.1.3.tgz",
+      "integrity": "sha512-NdobePNq5LUHCI1dJHUGlOTw+Qmq/FJre981/ELEMBdEs95kmKwnXB2UaLjAQYWkgkr4YS3lEnNpsiSTaEHFCg==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/functions": "0.7.2",
+        "@firebase/functions-types": "0.5.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.5.0.tgz",
+      "integrity": "sha512-qza0M5EwX+Ocrl1cYI14zoipUX4gI/Shwqv0C1nB864INAD42Dgv4v94BCyxGHBg2kzlWy8PNafdP7zPO8aJQA==",
+      "dev": true
+    },
+    "node_modules/@firebase/functions/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.5.1.tgz",
+      "integrity": "sha512-KZ1XHrEPmCx3Z70P9d8mHmYEZXA/uiLIkV0D8R45Q65c0DUxBDm5tSQs56QWofxB/wx16xmO3xAZw4BdJUBnlQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/util": "1.4.0",
+        "idb": "3.0.2",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-7oQ+TctqekfgZImWkKuda50JZfkmAKMgh5qY4aR4pwRyqZXuJXN1H/BKkHvN1y0S4XWtF0f/wiCLKHhyi1ppPA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/logger/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.9.1.tgz",
+      "integrity": "sha512-0g3JWTfkv0WHnu4xgx1zcChJXU2dLjWT0e2MI13Q7NbP3TgLu5CgQ/H/lad16j4Zb4RNqZbAUJurEAB6v2BJ/w==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/installations": "0.5.1",
+        "@firebase/messaging-interop-types": "0.1.0",
+        "@firebase/util": "1.4.0",
+        "idb": "3.0.2",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.1.1.tgz",
+      "integrity": "sha512-8FxrQjJCOfP9HibFsymT3qB18rBBmMPxOV+k0n6B7L6KW6Idswq01hMW12d93ZnvlNNKdikCKwUtBNbITBd8FA==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/messaging": "0.9.1",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.1.0.tgz",
+      "integrity": "sha512-DbvUl/rXAZpQeKBnwz0NYY5OCqr2nFA0Bj28Fmr3NXGqR4PAkfTOHuQlVtLO1Nudo3q0HxAYLa68ZDAcuv2uKQ==",
+      "dev": true
+    },
+    "node_modules/@firebase/messaging/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.5.1.tgz",
+      "integrity": "sha512-O93Yry8KhAaFrhnmBaMkM0lpgVmpd7CRX0eq1S0IKLdE3MdF+oAtbQiZG/NuRl3Vz8vjoz96R6bPbCWaDuiy8Q==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/installations": "0.5.1",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.1.1.tgz",
+      "integrity": "sha512-xN/TjU0hVNiJshZzrUvPYB+3sPS9SgaWrfxh3p0eGFVdwHp/3Z8HlT772bkHAEKXVc64v19ktpUVd+sF5aoJNQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/performance": "0.5.1",
+        "@firebase/performance-types": "0.1.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.1.0.tgz",
+      "integrity": "sha512-6p1HxrH0mpx+622Ql6fcxFxfkYSBpE3LSuwM7iTtYU2nw91Hj6THC8Bc8z4nboIq7WvgsT/kOTYVVZzCSlXl8w==",
+      "dev": true
+    },
+    "node_modules/@firebase/performance/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/polyfill": {
+      "version": "0.3.36",
+      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.36.tgz",
+      "integrity": "sha512-zMM9oSJgY6cT2jx3Ce9LYqb0eIpDE52meIzd/oe/y70F+v9u1LDqk5kUF5mf16zovGBWMNFmgzlsh6Wj0OsFtg==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "3.6.5",
+        "promise-polyfill": "8.1.3",
+        "whatwg-fetch": "2.0.4"
+      }
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.3.0.tgz",
+      "integrity": "sha512-Yf9/iXToC6Kbec1yOQ9mdTc1MP0mR2VCCR/n3Q+Ol3U+PML+ePXfqWiL2VHrUA86BeB2hpXF1BcTxvD4uOiDnA==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/installations": "0.5.1",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.1.1.tgz",
+      "integrity": "sha512-ZHRHYTdDztXHxgYXzuuD6Goa6ScmAqtctXl2eC6D8vxA8fIGRQKHN+9AMwxm8b3JHzdVY/5XhAOmKCcFvPOgtw==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/remote-config": "0.3.0",
+        "@firebase/remote-config-types": "0.2.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.2.0.tgz",
+      "integrity": "sha512-hqK5sCPeZvcHQ1D6VjJZdW6EexLTXNMJfPdTwbD8NrXUw6UjWC4KWhLK/TSlL0QPsQtcKRkaaoP+9QCgKfMFPw==",
+      "dev": true
+    },
+    "node_modules/@firebase/remote-config/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.8.3.tgz",
+      "integrity": "sha512-oraycQ787tEr6xu2Qc4nngLz1YEoEjZ+lrjThx0CJZB7VwdlkIJ24TkzJ9xoeWc+cpo34deg/If4w8AU5/WupQ==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/util": "1.4.0",
+        "node-fetch": "2.6.2",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.1.3.tgz",
+      "integrity": "sha512-m2htGJjCFlTONsqYRKXTfzkux3nbhpIpd72RK2iPkRPE69nQ0wiVplIE7bCaq3CSFMbkI3ETOtTTfW1wrOpF2g==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/component": "0.5.7",
+        "@firebase/storage": "0.8.3",
+        "@firebase/storage-types": "0.6.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.6.0.tgz",
+      "integrity": "sha512-1LpWhcCb1ftpkP/akhzjzeFxgVefs6eMD2QeKiJJUGH1qOiows2w5o0sKCUSQrvrRQS1lz3SFGvNR1Ck/gqxeA==",
+      "dev": true,
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/storage/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.4.0.tgz",
+      "integrity": "sha512-Qn58d+DVi1nGn0bA9RV89zkz0zcbt6aUcRdyiuub/SuEvjKYstWmHcHwh1C0qmE1wPf9a3a+AuaRtduaGaRT7A==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/util/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.6.0.tgz",
+      "integrity": "sha512-Pz4+7HPzKvOFI1ICQ6pyUv/VgStEWq9IGiVaaV1cQLi66NIA1mD5INnY4CDNoVAxlkuZvDEUZ+cVHLQ8iwA2hQ==",
+      "dev": true
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.3.7.tgz",
+      "integrity": "sha512-CKQVuwuSPh40tgOkR7c0ZisxYRiN05PcKPW72mQL5y++qd7CwBRoaJZvU5xfXnCJDFBmS3qZGQ71Frx6Ofo2XA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.5.tgz",
+      "integrity": "sha512-GZdzyVQI1Bln/kCzIYgTKu+rQJ5dno0gVrfmLe4jqQu7T2e7svSwJzpCBqVU5hhBSJP3peuPjOMWsj5GR61YmQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/long": "^4.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "long": "^4.0.0",
+        "protobufjs": "^6.10.0",
+        "yargs": "^16.1.1"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+      "dev": true
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+      "dev": true
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dev": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+      "dev": true
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+      "dev": true
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+      "dev": true
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+      "dev": true
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "dev": true
+    },
+    "node_modules/@types/acorn": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.5.tgz",
+      "integrity": "sha512-603sPiZ4GVRHPvn6vNgEAvJewKsy+zwRWYS2MeIMemgoAtcjlw2G3lALxrb9OPA17J28bkB71R33yXlQbUatCA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "16.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+      "integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w==",
+      "dev": true
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.0.tgz",
+      "integrity": "sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-dynamic-import": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+      "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^5.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/builtin-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-2.0.0.tgz",
+      "integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/core-js": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
+    "node_modules/csstype": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+      "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==",
+      "dev": true
+    },
+    "node_modules/date-time": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
+      "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
+      "dev": true,
+      "dependencies": {
+        "time-zone": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dev": true,
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-9.1.0.tgz",
+      "integrity": "sha512-Pj9/FwNzT4pdSS6vpXZzm4mFscI73N+AH70gaWZPnZrQBvyMAPTuKXXscjrFePPlqs94b4Emq+2mSwLGcwod/A==",
+      "dev": true,
+      "dependencies": {
+        "@firebase/analytics": "0.7.1",
+        "@firebase/analytics-compat": "0.1.2",
+        "@firebase/app": "0.7.1",
+        "@firebase/app-check": "0.4.1",
+        "@firebase/app-check-compat": "0.1.2",
+        "@firebase/app-compat": "0.1.2",
+        "@firebase/app-types": "0.7.0",
+        "@firebase/auth": "0.18.0",
+        "@firebase/auth-compat": "0.1.3",
+        "@firebase/database": "0.12.1",
+        "@firebase/database-compat": "0.1.1",
+        "@firebase/firestore": "3.1.0",
+        "@firebase/firestore-compat": "0.1.3",
+        "@firebase/functions": "0.7.2",
+        "@firebase/functions-compat": "0.1.3",
+        "@firebase/installations": "0.5.1",
+        "@firebase/messaging": "0.9.1",
+        "@firebase/messaging-compat": "0.1.1",
+        "@firebase/performance": "0.5.1",
+        "@firebase/performance-compat": "0.1.1",
+        "@firebase/polyfill": "0.3.36",
+        "@firebase/remote-config": "0.3.0",
+        "@firebase/remote-config-compat": "0.1.1",
+        "@firebase/storage": "0.8.3",
+        "@firebase/storage-compat": "0.1.3",
+        "@firebase/util": "1.4.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^3.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "dev": true
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
+      "dev": true
+    },
+    "node_modules/idb": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
+      "integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==",
+      "dev": true
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "dev": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
+    "node_modules/is-reference": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.3.tgz",
+      "integrity": "sha512-W1iHHv/oyBb2pPxkBxtaewxa1BC58Pn5J0hogyCdefwUIvb6R+TGbAcIa4qPNYLqLhb3EnOgUf2MQkkF76BcKw==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/jsonfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+      "dev": true,
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-2.0.5.tgz",
+      "integrity": "sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg==",
+      "dev": true
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+      "dev": true,
+      "dependencies": {
+        "vlq": "^0.2.2"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
+      "dev": true,
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
+    "node_modules/parse-ms": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "dev": true,
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",
+      "integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
+      "dev": true,
+      "dependencies": {
+        "parse-ms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
+      "dev": true
+    },
+    "node_modules/protobufjs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/react": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
+      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
+      "dev": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
+    },
+    "node_modules/resolve": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "dev": true,
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.57.1.tgz",
+      "integrity": "sha512-I18GBqP0qJoJC1K1osYjreqA8VAKovxuI3I81RSk0Dmr4TgloI0tAULjZaox8OsJ+n7XRrhH6i0G2By/pj1LCA==",
+      "dev": true,
+      "dependencies": {
+        "@types/acorn": "^4.0.3",
+        "acorn": "^5.5.3",
+        "acorn-dynamic-import": "^3.0.0",
+        "date-time": "^2.1.0",
+        "is-reference": "^1.1.0",
+        "locate-character": "^2.0.5",
+        "pretty-ms": "^3.1.0",
+        "require-relative": "^0.8.7",
+        "rollup-pluginutils": "^2.0.1",
+        "signal-exit": "^3.0.2",
+        "sourcemap-codec": "^1.4.1"
+      },
+      "bin": {
+        "rollup": "bin/rollup"
+      }
+    },
+    "node_modules/rollup-plugin-commonjs": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.1.0.tgz",
+      "integrity": "sha512-NrfE0g30QljNCnlJr7I2Xguz+44mh0dCxvfxwLnCwtaCK2LwFUp1zzAs8MQuOfhH4mRskqsjfOwGUap/L+WtEw==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-commonjs.",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^0.5.1",
+        "magic-string": "^0.22.4",
+        "resolve": "^1.5.0",
+        "rollup-pluginutils": "^2.0.1"
+      },
+      "peerDependencies": {
+        "rollup": ">=0.56.0"
+      }
+    },
+    "node_modules/rollup-plugin-commonjs/node_modules/estree-walker": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+      "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
+      "dev": true
+    },
+    "node_modules/rollup-plugin-copy": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-copy/-/rollup-plugin-copy-0.2.3.tgz",
+      "integrity": "sha1-2sGrgdHyILrrmOXEwBCCUuHtu5g=",
+      "dev": true,
+      "dependencies": {
+        "colors": "^1.1.2",
+        "fs-extra": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-plugin-node-resolve": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.3.0.tgz",
+      "integrity": "sha512-9zHGr3oUJq6G+X0oRMYlzid9fXicBdiydhwGChdyeNRGPcN/majtegApRKHLR5drboUvEWU+QeUmGTyEZQs3WA==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-node-resolve.",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^2.0.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.1.6"
+      }
+    },
+    "node_modules/rollup-plugin-typescript2": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.12.0.tgz",
+      "integrity": "sha512-UvHzfJyBWyV+d4Av7FG79PTipIK1VrNQoDrNWszAYd7i/ZcCfBg3rPkPiK9Z+WEHXeWBbCnxJlSqR2zKWgEkiw==",
+      "dev": true,
+      "dependencies": {
+        "fs-extra": "^5.0.0",
+        "resolve": "^1.5.0",
+        "rollup-pluginutils": "^2.0.1",
+        "tslib": "^1.9.0"
+      },
+      "peerDependencies": {
+        "rollup": ">=0.50.0",
+        "typescript": ">=2.4.0"
+      }
+    },
+    "node_modules/rollup-plugin-typescript2/node_modules/fs-extra": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/rollup-plugin-typescript2/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/rollup-plugin-uglify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-3.0.0.tgz",
+      "integrity": "sha512-dehLu9eRRoV4l09aC+ySntRw1OAfoyKdbk8Nelblj03tHoynkSybqyEpgavemi1LBOH6S1vzI58/mpxkZIe1iQ==",
+      "dev": true,
+      "dependencies": {
+        "uglify-es": "^3.3.7"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
+      "integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/selenium-webdriver": {
+      "version": "4.0.0-rc-1",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-rc-1.tgz",
+      "integrity": "sha512-bcrwFPRax8fifRP60p7xkWDGSJJoMkPAzufMlk5K2NyLPht/YZzR2WcIk1+3gR8VOCLlst1P2PI+MXACaFzpIw==",
+      "dev": true,
+      "dependencies": {
+        "jszip": "^3.6.0",
+        "rimraf": "^3.0.2",
+        "tmp": "^0.2.1",
+        "ws": ">=7.4.6"
+      },
+      "engines": {
+        "node": ">= 10.15.0"
+      }
+    },
+    "node_modules/selenium-webdriver/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
+      "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/time-zone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
+      "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "dependencies": {
+        "rimraf": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0"
+      }
+    },
+    "node_modules/tmp/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
+      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uglify-es": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+      "deprecated": "support for ECMAScript is superseded by `uglify-js` as of v3.13.0",
+      "dev": true,
+      "dependencies": {
+        "commander": "~2.13.0",
+        "source-map": "~0.6.1"
+      },
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+      "dev": true
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dev": true,
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-Q6B6H2oc8QY3llc3cB8kVmQ6pnJWVQbP7Q5algTcIxx7YEpc0oU4NBVHlztA7Ekzfhw2r0rPducMUiCGWKQRzw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  },
   "dependencies": {
     "@firebase/analytics": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.2.tgz",
-      "integrity": "sha512-4Ceov+rPfOEPIdbjlpTim/wbcUUneIesHag4UOzvmFsRRXqbxLwQpyZQWEbTSriUeU8uTKj9yOW32hsskV9Klg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.7.1.tgz",
+      "integrity": "sha512-fTUN47UK4obzIJwmgLMJU46dWZ7pzitCEO+80pQZC7mdLlVs/NW0+tMf6rETwMpKjGSgb25cKidpgEuioQtT7w==",
       "dev": true,
       "requires": {
-        "@firebase/analytics-types": "0.4.0",
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
-        "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.4",
-        "tslib": "^1.11.1"
+        "@firebase/component": "0.5.7",
+        "@firebase/installations": "0.5.1",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/analytics-compat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.1.2.tgz",
+      "integrity": "sha512-TpWpz0s8EgVt9aqyOCFktONqVkjyrNRR4esn3cEYrueH+XXSMDLWY9oFHuUJzntcoEOlOBWMvpsJCPG/1kthkg==",
+      "dev": true,
+      "requires": {
+        "@firebase/analytics": "0.7.1",
+        "@firebase/analytics-types": "0.7.0",
+        "@firebase/component": "0.5.7",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
     },
     "@firebase/analytics-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.4.0.tgz",
-      "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.7.0.tgz",
+      "integrity": "sha512-DNE2Waiwy5+zZnCfintkDtBfaW6MjIG883474v6Z0K1XZIvl76cLND4iv0YUb48leyF+PJK1KO2XrgHb/KpmhQ==",
       "dev": true
     },
     "@firebase/app": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.13.tgz",
-      "integrity": "sha512-xGrJETzvCb89VYbGSHFHCW7O/y067HRxT7MGehUE1xMxdPVBDNayHnxEuKwzfGvXAjVmajXBKFlKxaCWpgSjCQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.1.tgz",
+      "integrity": "sha512-B4z6E1EPQc0mOjF35IPKdDRCFnT/fNQIHfM+v7F9obB7ItPhGILK3LxaQfuampSQpF6GG6TPFDbrWK6myXAq+g==",
       "dev": true,
       "requires": {
-        "@firebase/app-types": "0.6.1",
-        "@firebase/component": "0.1.21",
-        "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.4",
-        "dom-storage": "2.1.0",
-        "tslib": "^1.11.1",
-        "xmlhttprequest": "1.8.0"
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/app-check": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.4.1.tgz",
+      "integrity": "sha512-Kpqh0Y2zpx+acTL7eOVYIWBOmAwoconJpqOAlByGNXuxm/ccP00XREo+HsqaC7wapZRXh+h8BK0jZjvdV36qow==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/app-check-compat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.1.2.tgz",
+      "integrity": "sha512-JB+OHk4Cp9ZgT+UfX0A+lwH1AoM5Y2X1rDhmhCsEXcKKwz1w9DpL9PjStciP8UYg1dpqbp5p9OMxmty+21EBsA==",
+      "dev": true,
+      "requires": {
+        "@firebase/app-check": "0.4.1",
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/app-check-interop-types": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.1.0.tgz",
+      "integrity": "sha512-uZfn9s4uuRsaX5Lwx+gFP3B6YsyOKUE+Rqa6z9ojT4VSRAsZFko9FRn6OxQUA1z5t5d08fY4pf+/+Dkd5wbdbA==",
+      "dev": true
+    },
+    "@firebase/app-compat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.2.tgz",
+      "integrity": "sha512-kF1maoqA8bZqJ4v/ojVvA7kIyyXEPkJmL48otGrC8LIgdcen7xCx3JFDe0DGeQywg+qujvdkJz/TptFN1cvAgw==",
+      "dev": true,
+      "requires": {
+        "@firebase/app": "0.7.1",
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
     },
     "@firebase/app-types": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
-      "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.7.0.tgz",
+      "integrity": "sha512-6fbHQwDv2jp/v6bXhBw2eSRbNBpxHcd1NBF864UksSMVIqIyri9qpJB1Mn6sGZE+bnDsSQBC5j2TbMxYsJQkQg==",
       "dev": true
     },
     "@firebase/auth": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.15.3.tgz",
-      "integrity": "sha512-nGJ0sVRgfd6ly4MyKhc1wyVoINLpQsxJ7uasw30qTssPdDQFus8uDu6Kmy0nN2XzRpYAfchQzZRHE9Q5Y2FHqA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.18.0.tgz",
+      "integrity": "sha512-iK+VXkdDkum8SmJNgz9ZcOboRLrUN1VW7AHHkpZb76VJvoYRoCPD+A9O/v/ziI0LpwIZJwi1GFes9XjZTlfLiA==",
       "dev": true,
       "requires": {
-        "@firebase/auth-types": "0.10.1"
-      }
-    },
-    "@firebase/auth-interop-types": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz",
-      "integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw==",
-      "dev": true
-    },
-    "@firebase/auth-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.1.tgz",
-      "integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw==",
-      "dev": true
-    },
-    "@firebase/component": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.21.tgz",
-      "integrity": "sha512-kd5sVmCLB95EK81Pj+yDTea8pzN2qo/1yr0ua9yVi6UgMzm6zAeih73iVUkaat96MAHy26yosMufkvd3zC4IKg==",
-      "dev": true,
-      "requires": {
-        "@firebase/util": "0.3.4",
-        "tslib": "^1.11.1"
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "node-fetch": "2.6.2",
+        "selenium-webdriver": "4.0.0-rc-1",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/auth-compat": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.1.3.tgz",
+      "integrity": "sha512-eDDtY5If+ERJxalt+plvX6avZspuwo4/kPXssvV+csm414awhDzQBtSDPDajgbH3YB9V+O3LAFHeWcP3rrHS5w==",
+      "dev": true,
+      "requires": {
+        "@firebase/auth": "0.18.0",
+        "@firebase/auth-types": "0.11.0",
+        "@firebase/component": "0.5.7",
+        "@firebase/util": "1.4.0",
+        "node-fetch": "2.6.2",
+        "selenium-webdriver": "^4.0.0-beta.2",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/auth-interop-types": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
+      "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==",
+      "dev": true,
+      "requires": {}
+    },
+    "@firebase/auth-types": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.11.0.tgz",
+      "integrity": "sha512-q7Bt6cx+ySj9elQHTsKulwk3+qDezhzRBFC9zlQ1BjgMueUOnGMcvqmU0zuKlQ4RhLSH7MNAdBV2znVaoN3Vxw==",
+      "dev": true,
+      "requires": {}
+    },
+    "@firebase/component": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.7.tgz",
+      "integrity": "sha512-CiAHUPXh2hn/lpzMShNmfAxHNQhKQwmQUJSYMPCjf2bCCt4Z2vLGpS+UWEuNFm9Zf8LNmkS+Z+U/s4Obi5carg==",
+      "dev": true,
+      "requires": {
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
     },
     "@firebase/database": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.8.1.tgz",
-      "integrity": "sha512-/1HhR4ejpqUaM9Cn3KSeNdQvdlehWIhdfTVWFxS73ZlLYf7ayk9jITwH10H3ZOIm5yNzxF67p/U7Z/0IPhgWaQ==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.12.1.tgz",
+      "integrity": "sha512-Ethk0hc476qnkSKNBa+8Yc7iM8AO69HYWsaD+QUC983FZtnuMyNLHtEeSUbLQYvyHo7cOjcc52slop14WmfZeQ==",
       "dev": true,
       "requires": {
-        "@firebase/auth-interop-types": "0.1.5",
-        "@firebase/component": "0.1.21",
-        "@firebase/database-types": "0.6.1",
-        "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.4",
-        "faye-websocket": "0.11.3",
-        "tslib": "^1.11.1"
+        "@firebase/auth-interop-types": "0.1.6",
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/database-compat": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.1.1.tgz",
+      "integrity": "sha512-K3DFWiw0YkLZtlfA9TOGPw6zVXKu5dQ1XqIGztUufFVRYW8IizReXVxzSSmJNR4Adr2LiU9j66Wenc6e5UfwaQ==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.7",
+        "@firebase/database": "0.12.1",
+        "@firebase/database-types": "0.9.1",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
     },
     "@firebase/database-types": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.6.1.tgz",
-      "integrity": "sha512-JtL3FUbWG+bM59iYuphfx9WOu2Mzf0OZNaqWiQ7lJR8wBe7bS9rIm9jlBFtksB7xcya1lZSQPA/GAy2jIlMIkA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.1.tgz",
+      "integrity": "sha512-RUixK/YrbpxbfdE+nYP0wMcEsz1xPTnafP0q3UlSS/+fW744OITKtR1J0cMRaXbvY7EH0wUVTNVkrtgxYY8IgQ==",
       "dev": true,
       "requires": {
-        "@firebase/app-types": "0.6.1"
+        "@firebase/app-types": "0.7.0",
+        "@firebase/util": "1.4.0"
       }
     },
     "@firebase/firestore": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.0.5.tgz",
-      "integrity": "sha512-RBA2A/tnA6ZFQY3pD0TJXRzjB9+D+zaLXzvTVxTO/Sxt8l2cRNFiQhYvHihD6aV/jm3n7RUQ2U7TDtzfXq7jjQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-3.1.0.tgz",
+      "integrity": "sha512-vOXueHNRjlgBlKVCWuUDhr3dQW2hJwbcqcJaFiIV9V+PamfyhOHzX8pEQkrPort4YQQvoRmY9uiFhfOGj2hbeA==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/firestore-types": "2.0.0",
-        "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.4",
-        "@firebase/webchannel-wrapper": "0.4.1",
-        "@grpc/grpc-js": "^1.0.0",
-        "@grpc/proto-loader": "^0.5.0",
-        "node-fetch": "2.6.1",
-        "tslib": "^1.11.1"
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "@firebase/webchannel-wrapper": "0.6.0",
+        "@grpc/grpc-js": "^1.3.2",
+        "@grpc/proto-loader": "^0.6.0",
+        "node-fetch": "2.6.2",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/firestore-compat": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.1.3.tgz",
+      "integrity": "sha512-tO3uAkIguKeFeKPu99GR7F7v1/Hc8nV1h7B1kdpkVRRBe+NfVYA3qAUictQ3OAA0oy7Ae9z4SfEURO/R1b6YlQ==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.7",
+        "@firebase/firestore": "3.1.0",
+        "@firebase/firestore-types": "2.5.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
     },
     "@firebase/firestore-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.0.0.tgz",
-      "integrity": "sha512-ZGb7p1SSQJP0Z+kc9GAUi+Fx5rJatFddBrS1ikkayW+QHfSIz0omU23OgSHcBGTxe8dJCeKiKA2Yf+tkDKO/LA==",
-      "dev": true
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.5.0.tgz",
+      "integrity": "sha512-I6c2m1zUhZ5SH0cWPmINabDyH5w0PPFHk2UHsjBpKdZllzJZ2TwTkXbDtpHUZNmnc/zAa0WNMNMvcvbb/xJLKA==",
+      "dev": true,
+      "requires": {}
     },
     "@firebase/functions": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.1.tgz",
-      "integrity": "sha512-xNCAY3cLlVWE8Azf+/84OjnaXMoyUstJ3vwVRG0ie22QhsdQuPa1tXTiPX4Tmm+Hbbd/Aw0A/7dkEnuW+zYzaQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.7.2.tgz",
+      "integrity": "sha512-B+b57xXtpsRYD3UgVtteeyavXjXfBTtuv+sG8LA0vgJs6bhORswVlKZQqpfW9SDxCMBwzzytzn1m3ZZGfUw2Lg==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/functions-types": "0.4.0",
-        "@firebase/messaging-types": "0.5.0",
-        "node-fetch": "2.6.1",
-        "tslib": "^1.11.1"
+        "@firebase/app-check-interop-types": "0.1.0",
+        "@firebase/auth-interop-types": "0.1.6",
+        "@firebase/component": "0.5.7",
+        "@firebase/messaging-interop-types": "0.1.0",
+        "@firebase/util": "1.4.0",
+        "node-fetch": "2.6.2",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/functions-compat": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.1.3.tgz",
+      "integrity": "sha512-NdobePNq5LUHCI1dJHUGlOTw+Qmq/FJre981/ELEMBdEs95kmKwnXB2UaLjAQYWkgkr4YS3lEnNpsiSTaEHFCg==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.7",
+        "@firebase/functions": "0.7.2",
+        "@firebase/functions-types": "0.5.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
     },
     "@firebase/functions-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.4.0.tgz",
-      "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.5.0.tgz",
+      "integrity": "sha512-qza0M5EwX+Ocrl1cYI14zoipUX4gI/Shwqv0C1nB864INAD42Dgv4v94BCyxGHBg2kzlWy8PNafdP7zPO8aJQA==",
       "dev": true
     },
     "@firebase/installations": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.19.tgz",
-      "integrity": "sha512-QqAQzosKVVqIx7oMt5ujF4NsIXgtlTnej4JXGJ8sQQuJoMnt3T+PFQRHbr7uOfVaBiHYhEaXCcmmhfKUHwKftw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.5.1.tgz",
+      "integrity": "sha512-KZ1XHrEPmCx3Z70P9d8mHmYEZXA/uiLIkV0D8R45Q65c0DUxBDm5tSQs56QWofxB/wx16xmO3xAZw4BdJUBnlQ==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations-types": "0.3.4",
-        "@firebase/util": "0.3.4",
+        "@firebase/component": "0.5.7",
+        "@firebase/util": "1.4.0",
         "idb": "3.0.2",
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
-    },
-    "@firebase/installations-types": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.3.4.tgz",
-      "integrity": "sha512-RfePJFovmdIXb6rYwtngyxuEcWnOrzdZd9m7xAW0gRxDIjBT20n3BOhjpmgRWXo/DAxRmS7bRjWAyTHY9cqN7Q==",
-      "dev": true
     },
     "@firebase/logger": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
-      "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
-      "dev": true
-    },
-    "@firebase/messaging": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.3.tgz",
-      "integrity": "sha512-63nOP2SmQJrj9jrhV3K96L5MRKS6AqmFVLX1XbGk6K6lz38ZC4LIoCcHxzUBXY7fCAuZvNmh/YB3pE8B2mTs8A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-7oQ+TctqekfgZImWkKuda50JZfkmAKMgh5qY4aR4pwRyqZXuJXN1H/BKkHvN1y0S4XWtF0f/wiCLKHhyi1ppPA==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
-        "@firebase/messaging-types": "0.5.0",
-        "@firebase/util": "0.3.4",
-        "idb": "3.0.2",
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
     },
-    "@firebase/messaging-types": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.5.0.tgz",
-      "integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg==",
+    "@firebase/messaging": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.9.1.tgz",
+      "integrity": "sha512-0g3JWTfkv0WHnu4xgx1zcChJXU2dLjWT0e2MI13Q7NbP3TgLu5CgQ/H/lad16j4Zb4RNqZbAUJurEAB6v2BJ/w==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.7",
+        "@firebase/installations": "0.5.1",
+        "@firebase/messaging-interop-types": "0.1.0",
+        "@firebase/util": "1.4.0",
+        "idb": "3.0.2",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/messaging-compat": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.1.1.tgz",
+      "integrity": "sha512-8FxrQjJCOfP9HibFsymT3qB18rBBmMPxOV+k0n6B7L6KW6Idswq01hMW12d93ZnvlNNKdikCKwUtBNbITBd8FA==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.7",
+        "@firebase/messaging": "0.9.1",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/messaging-interop-types": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.1.0.tgz",
+      "integrity": "sha512-DbvUl/rXAZpQeKBnwz0NYY5OCqr2nFA0Bj28Fmr3NXGqR4PAkfTOHuQlVtLO1Nudo3q0HxAYLa68ZDAcuv2uKQ==",
       "dev": true
     },
     "@firebase/performance": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.4.tgz",
-      "integrity": "sha512-CY/fzz7qGQ9hUkvOow22MeJhayHSjXmI4+0AqcxaUC4CWk4oQubyIC4pk62aH+yCwZNNeC7JJUEDbtqI/0rGkQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.5.1.tgz",
+      "integrity": "sha512-O93Yry8KhAaFrhnmBaMkM0lpgVmpd7CRX0eq1S0IKLdE3MdF+oAtbQiZG/NuRl3Vz8vjoz96R6bPbCWaDuiy8Q==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
-        "@firebase/logger": "0.2.6",
-        "@firebase/performance-types": "0.0.13",
-        "@firebase/util": "0.3.4",
-        "tslib": "^1.11.1"
+        "@firebase/component": "0.5.7",
+        "@firebase/installations": "0.5.1",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/performance-compat": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.1.1.tgz",
+      "integrity": "sha512-xN/TjU0hVNiJshZzrUvPYB+3sPS9SgaWrfxh3p0eGFVdwHp/3Z8HlT772bkHAEKXVc64v19ktpUVd+sF5aoJNQ==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/performance": "0.5.1",
+        "@firebase/performance-types": "0.1.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
     },
     "@firebase/performance-types": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.0.13.tgz",
-      "integrity": "sha512-6fZfIGjQpwo9S5OzMpPyqgYAUZcFzZxHFqOyNtorDIgNXq33nlldTL/vtaUZA8iT9TT5cJlCrF/jthKU7X21EA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.1.0.tgz",
+      "integrity": "sha512-6p1HxrH0mpx+622Ql6fcxFxfkYSBpE3LSuwM7iTtYU2nw91Hj6THC8Bc8z4nboIq7WvgsT/kOTYVVZzCSlXl8w==",
       "dev": true
     },
     "@firebase/polyfill": {
@@ -291,101 +2414,145 @@
       }
     },
     "@firebase/remote-config": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.30.tgz",
-      "integrity": "sha512-LAfLDcp1AN0V/7AkxBuTKy+Qnq9fKYKxbA5clrXRNVzJbTVnF5eFGsaUOlkes0ESG6lbqKy5ZcDgdl73zBIhAA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.3.0.tgz",
+      "integrity": "sha512-Yf9/iXToC6Kbec1yOQ9mdTc1MP0mR2VCCR/n3Q+Ol3U+PML+ePXfqWiL2VHrUA86BeB2hpXF1BcTxvD4uOiDnA==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/installations": "0.4.19",
-        "@firebase/logger": "0.2.6",
-        "@firebase/remote-config-types": "0.1.9",
-        "@firebase/util": "0.3.4",
-        "tslib": "^1.11.1"
+        "@firebase/component": "0.5.7",
+        "@firebase/installations": "0.5.1",
+        "@firebase/logger": "0.3.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/remote-config-compat": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.1.1.tgz",
+      "integrity": "sha512-ZHRHYTdDztXHxgYXzuuD6Goa6ScmAqtctXl2eC6D8vxA8fIGRQKHN+9AMwxm8b3JHzdVY/5XhAOmKCcFvPOgtw==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.7",
+        "@firebase/logger": "0.3.0",
+        "@firebase/remote-config": "0.3.0",
+        "@firebase/remote-config-types": "0.2.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
     },
     "@firebase/remote-config-types": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.1.9.tgz",
-      "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.2.0.tgz",
+      "integrity": "sha512-hqK5sCPeZvcHQ1D6VjJZdW6EexLTXNMJfPdTwbD8NrXUw6UjWC4KWhLK/TSlL0QPsQtcKRkaaoP+9QCgKfMFPw==",
       "dev": true
     },
     "@firebase/storage": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.2.tgz",
-      "integrity": "sha512-87CrvKrf8kijVekRBmUs8htsNz7N5X/pDhv3BvJBqw8K65GsUolpyjx0f4QJRkCRUYmh3MSkpa5P08lpVbC6nQ==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.8.3.tgz",
+      "integrity": "sha512-oraycQ787tEr6xu2Qc4nngLz1YEoEjZ+lrjThx0CJZB7VwdlkIJ24TkzJ9xoeWc+cpo34deg/If4w8AU5/WupQ==",
       "dev": true,
       "requires": {
-        "@firebase/component": "0.1.21",
-        "@firebase/storage-types": "0.3.13",
-        "@firebase/util": "0.3.4",
-        "tslib": "^1.11.1"
+        "@firebase/component": "0.5.7",
+        "@firebase/util": "1.4.0",
+        "node-fetch": "2.6.2",
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/storage-compat": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.1.3.tgz",
+      "integrity": "sha512-m2htGJjCFlTONsqYRKXTfzkux3nbhpIpd72RK2iPkRPE69nQ0wiVplIE7bCaq3CSFMbkI3ETOtTTfW1wrOpF2g==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.5.7",
+        "@firebase/storage": "0.8.3",
+        "@firebase/storage-types": "0.6.0",
+        "@firebase/util": "1.4.0",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
     },
     "@firebase/storage-types": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
-      "integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog==",
-      "dev": true
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.6.0.tgz",
+      "integrity": "sha512-1LpWhcCb1ftpkP/akhzjzeFxgVefs6eMD2QeKiJJUGH1qOiows2w5o0sKCUSQrvrRQS1lz3SFGvNR1Ck/gqxeA==",
+      "dev": true,
+      "requires": {}
     },
     "@firebase/util": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.4.tgz",
-      "integrity": "sha512-VwjJUE2Vgr2UMfH63ZtIX9Hd7x+6gayi6RUXaTqEYxSbf/JmehLmAEYSuxS/NckfzAXWeGnKclvnXVibDgpjQQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.4.0.tgz",
+      "integrity": "sha512-Qn58d+DVi1nGn0bA9RV89zkz0zcbt6aUcRdyiuub/SuEvjKYstWmHcHwh1C0qmE1wPf9a3a+AuaRtduaGaRT7A==",
       "dev": true,
       "requires": {
-        "tslib": "^1.11.1"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
     },
     "@firebase/webchannel-wrapper": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.1.tgz",
-      "integrity": "sha512-0yPjzuzGMkW1GkrC8yWsiN7vt1OzkMIi9HgxRmKREZl2wnNPOKo/yScTjXf/O57HM8dltqxPF6jlNLFVtc2qdw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.6.0.tgz",
+      "integrity": "sha512-Pz4+7HPzKvOFI1ICQ6pyUv/VgStEWq9IGiVaaV1cQLi66NIA1mD5INnY4CDNoVAxlkuZvDEUZ+cVHLQ8iwA2hQ==",
       "dev": true
     },
     "@grpc/grpc-js": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.2.tgz",
-      "integrity": "sha512-iK/T984Ni6VnmlQK/LJdUk+VsXSaYIWkgzJ0LyOcxN2SowAmoRjG28kS7B1ui/q/MAv42iM3051WBt5QorFxmg==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.3.7.tgz",
+      "integrity": "sha512-CKQVuwuSPh40tgOkR7c0ZisxYRiN05PcKPW72mQL5y++qd7CwBRoaJZvU5xfXnCJDFBmS3qZGQ71Frx6Ofo2XA==",
       "dev": true,
       "requires": {
-        "@types/node": "^12.12.47",
-        "google-auth-library": "^6.1.1",
-        "semver": "^6.2.0"
+        "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.5.tgz",
-      "integrity": "sha512-WwN9jVNdHRQoOBo9FDH7qU+mgfjPc8GygPYms3M+y3fbQLfnCe/Kv/E01t7JRgnrsOHH8euvSbed3mIalXhwqQ==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.5.tgz",
+      "integrity": "sha512-GZdzyVQI1Bln/kCzIYgTKu+rQJ5dno0gVrfmLe4jqQu7T2e7svSwJzpCBqVU5hhBSJP3peuPjOMWsj5GR61YmQ==",
       "dev": true,
       "requires": {
+        "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
-        "protobufjs": "^6.8.6"
+        "long": "^4.0.0",
+        "protobufjs": "^6.10.0",
+        "yargs": "^16.1.1"
       }
     },
     "@protobufjs/aspromise": {
@@ -474,9 +2641,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.8.tgz",
-      "integrity": "sha512-D4k2kNi0URNBxIRCb1khTnkWNHv8KSL1owPmS/K5e5t8B2GzMReY7AsJIY1BnP5KdlgC4rj9jk2IkDMasIE7xg==",
+      "version": "16.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.1.tgz",
+      "integrity": "sha512-4/Z9DMPKFexZj/Gn3LylFgamNKHm4K3QDi0gz9B26Uk0c8izYf97B5fxfpspMNkWlFupblKM/nV8+NA9Ffvr+w==",
       "dev": true
     },
     "@types/prop-types": {
@@ -495,15 +2662,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
-    },
     "acorn": {
       "version": "5.7.4",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
@@ -519,37 +2677,25 @@
         "acorn": "^5.0.0"
       }
     },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "requires": {
-        "debug": "4"
+        "color-convert": "^2.0.1"
       }
-    },
-    "arrify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
-    },
-    "bignumber.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
       "dev": true
     },
     "brace-expansion": {
@@ -562,16 +2708,36 @@
         "concat-map": "0.0.1"
       }
     },
-    "buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-      "dev": true
-    },
     "builtin-modules": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-2.0.0.tgz",
       "integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==",
+      "dev": true
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "colors": {
@@ -598,6 +2764,12 @@
       "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
       "dev": true
     },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
     "csstype": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
@@ -613,29 +2785,17 @@
         "time-zone": "^1.0.0"
       }
     },
-    "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
-      "requires": {
-        "ms": "2.1.2"
-      }
-    },
-    "dom-storage": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
-      "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
-    "ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "estree-walker": {
       "version": "0.6.1",
@@ -643,53 +2803,47 @@
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
       "dev": true
     },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
-    },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
-    },
-    "fast-text-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==",
-      "dev": true
-    },
     "faye-websocket": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"
       }
     },
     "firebase": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.1.2.tgz",
-      "integrity": "sha512-I1nYPQpE22sKWKc4A4GQNl0k0G1IbPZ5KvyzwEP4fAkLSX9j1rNwh7S902CJIjUxOXV/QOU7e/gYtNRc5SX98Q==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-9.1.0.tgz",
+      "integrity": "sha512-Pj9/FwNzT4pdSS6vpXZzm4mFscI73N+AH70gaWZPnZrQBvyMAPTuKXXscjrFePPlqs94b4Emq+2mSwLGcwod/A==",
       "dev": true,
       "requires": {
-        "@firebase/analytics": "0.6.2",
-        "@firebase/app": "0.6.13",
-        "@firebase/app-types": "0.6.1",
-        "@firebase/auth": "0.15.3",
-        "@firebase/database": "0.8.1",
-        "@firebase/firestore": "2.0.5",
-        "@firebase/functions": "0.6.1",
-        "@firebase/installations": "0.4.19",
-        "@firebase/messaging": "0.7.3",
-        "@firebase/performance": "0.4.4",
+        "@firebase/analytics": "0.7.1",
+        "@firebase/analytics-compat": "0.1.2",
+        "@firebase/app": "0.7.1",
+        "@firebase/app-check": "0.4.1",
+        "@firebase/app-check-compat": "0.1.2",
+        "@firebase/app-compat": "0.1.2",
+        "@firebase/app-types": "0.7.0",
+        "@firebase/auth": "0.18.0",
+        "@firebase/auth-compat": "0.1.3",
+        "@firebase/database": "0.12.1",
+        "@firebase/database-compat": "0.1.1",
+        "@firebase/firestore": "3.1.0",
+        "@firebase/firestore-compat": "0.1.3",
+        "@firebase/functions": "0.7.2",
+        "@firebase/functions-compat": "0.1.3",
+        "@firebase/installations": "0.5.1",
+        "@firebase/messaging": "0.9.1",
+        "@firebase/messaging-compat": "0.1.1",
+        "@firebase/performance": "0.5.1",
+        "@firebase/performance-compat": "0.1.1",
         "@firebase/polyfill": "0.3.36",
-        "@firebase/remote-config": "0.1.30",
-        "@firebase/storage": "0.4.2",
-        "@firebase/util": "0.3.4"
+        "@firebase/remote-config": "0.3.0",
+        "@firebase/remote-config-compat": "0.1.1",
+        "@firebase/storage": "0.8.3",
+        "@firebase/storage-compat": "0.1.3",
+        "@firebase/util": "1.4.0"
       }
     },
     "fs-extra": {
@@ -709,28 +2863,11 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "gaxios": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
-      "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
-      "dev": true,
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.3.0"
-      }
-    },
-    "gcp-metadata": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
-      "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
-      "dev": true,
-      "requires": {
-        "gaxios": "^4.0.0",
-        "json-bigint": "^1.0.0"
-      }
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "glob": {
       "version": "7.1.4",
@@ -746,70 +2883,28 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "google-auth-library": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.3.tgz",
-      "integrity": "sha512-m9mwvY3GWbr7ZYEbl61isWmk+fvTmOt0YNUfPOUY2VH8K5pZlAIWJjxEi0PqR3OjMretyiQLI6GURMrPSwHQ2g==",
-      "dev": true,
-      "requires": {
-        "arrify": "^2.0.0",
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "fast-text-encoding": "^1.0.0",
-        "gaxios": "^4.0.0",
-        "gcp-metadata": "^4.2.0",
-        "gtoken": "^5.0.4",
-        "jws": "^4.0.0",
-        "lru-cache": "^6.0.0"
-      }
-    },
-    "google-p12-pem": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
-      "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
-      "dev": true,
-      "requires": {
-        "node-forge": "^0.10.0"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
       "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
       "dev": true
     },
-    "gtoken": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.1.0.tgz",
-      "integrity": "sha512-4d8N6Lk8TEAHl9vVoRVMh9BNOKWVgl2DdNtr3428O75r3QFrF/a5MMu851VmK0AA8+iSvbwRv69k5XnMLURGhg==",
-      "dev": true,
-      "requires": {
-        "gaxios": "^4.0.0",
-        "google-p12-pem": "^3.0.3",
-        "jws": "^4.0.0",
-        "mime": "^2.2.0"
-      }
-    },
     "http-parser-js": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.2.tgz",
-      "integrity": "sha512-opCO9ASqg5Wy2FNo7A0sxy71yGbbkJJXLdgMK04Tcypw9jr2MgWbyubb0+WdmDmGnFflO7fRbqbaihh/ENDlRQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
       "dev": true
-    },
-    "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      }
     },
     "idb": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
       "integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==",
+      "dev": true
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
       "dev": true
     },
     "inflight": {
@@ -828,6 +2923,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -843,10 +2944,10 @@
         "@types/estree": "0.0.39"
       }
     },
-    "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "js-tokens": {
@@ -854,15 +2955,6 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
-    },
-    "json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "dev": true,
-      "requires": {
-        "bignumber.js": "^9.0.0"
-      }
     },
     "jsonfile": {
       "version": "3.0.1",
@@ -873,25 +2965,25 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+    "jszip": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
       "dev": true,
       "requires": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
       }
     },
-    "jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
       "dev": true,
       "requires": {
-        "jwa": "^2.0.0",
-        "safe-buffer": "^5.0.1"
+        "immediate": "~3.0.5"
       }
     },
     "locate-character": {
@@ -921,15 +3013,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "magic-string": {
       "version": "0.22.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
@@ -938,12 +3021,6 @@
       "requires": {
         "vlq": "^0.2.2"
       }
-    },
-    "mime": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -954,22 +3031,10 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
-    },
-    "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
       "dev": true
     },
     "object-assign": {
@@ -986,6 +3051,12 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
     },
     "parse-ms": {
       "version": "1.0.1",
@@ -1036,6 +3107,12 @@
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
     "promise-polyfill": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
@@ -1043,9 +3120,9 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
-      "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
       "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -1059,16 +3136,8 @@
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
         "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
+        "@types/node": ">=13.7.0",
         "long": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.35",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.35.tgz",
-          "integrity": "sha512-q9aeOGwv+RRou/ca4aJVUM/jD5u7LBexu+rq9PkA/NhHNn8JifcMo94soKm0b6JGSfw/PSNdqtc428OscMvEYA==",
-          "dev": true
-        }
       }
     },
     "react": {
@@ -1080,6 +3149,27 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "require-relative": {
       "version": "0.8.7",
@@ -1218,15 +3308,38 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
-    "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+    "selenium-webdriver": {
+      "version": "4.0.0-rc-1",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-rc-1.tgz",
+      "integrity": "sha512-bcrwFPRax8fifRP60p7xkWDGSJJoMkPAzufMlk5K2NyLPht/YZzR2WcIk1+3gR8VOCLlst1P2PI+MXACaFzpIw==",
+      "dev": true,
+      "requires": {
+        "jszip": "^3.6.0",
+        "rimraf": "^3.0.2",
+        "tmp": "^0.2.1",
+        "ws": ">=7.4.6"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
     "signal-exit": {
@@ -1247,11 +3360,60 @@
       "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
     "time-zone": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
       "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
       "dev": true
+    },
+    "tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "requires": {
+        "rimraf": "^3.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "tslib": {
       "version": "1.9.3",
@@ -1298,6 +3460,12 @@
         }
       }
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
     "vlq": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
@@ -1327,22 +3495,55 @@
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
       "dev": true
     },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+    "ws": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-Q6B6H2oc8QY3llc3cB8kVmQ6pnJWVQbP7Q5algTcIxx7YEpc0oU4NBVHlztA7Ekzfhw2r0rPducMUiCGWKQRzw==",
+      "dev": true,
+      "requires": {}
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
     },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "react-firebase-hooks",
-  "version": "3.0.4",
+  "name": "react-firebase-hooks-v9",
+  "version": "4.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "react-firebase-hooks",
-      "version": "3.0.4",
+      "name": "react-firebase-hooks-v9",
+      "version": "4.0.0-alpha.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/react": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-firebase-hooks",
-  "version": "3.0.4",
+  "name": "react-firebase-hooks-v9",
+  "version": "4.0.0-alpha.0",
   "description": "React Hooks for Firebase",
   "author": "CS Frequency Limited (https://csfrequency.com)",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {},
   "devDependencies": {
     "@types/react": "^17.0.0",
-    "firebase": "^8.0.0",
+    "firebase": "9.1.0",
     "path": "^0.12.7",
     "prettier": "2.2.1",
     "react": "^17.0.1",
@@ -67,7 +67,7 @@
   },
   "peerDependencies": {
     "react": ">= 16.8.0",
-    "firebase": ">= 8.0.0"
+    "firebase": ">= 9.0.0"
   },
   "typings": "index.d.ts"
 }

--- a/storage/README.md
+++ b/storage/README.md
@@ -1,7 +1,7 @@
 # React Firebase Hooks - Cloud Storage
 
 React Firebase Hooks provides convenience listeners for files stored within
-Firebase Cloud Storage. The hooks wrap around the `firebase.storage().ref().getDownloadURL()` method.
+Firebase Cloud Storage. The hooks wrap around the `getDownloadURL(ref(storage, 'path/to/file'))` method.
 
 In addition to returning the download URL, the hooks provide an `error` and `loading` property
 to give a complete lifecycle for loading from Cloud Storage.
@@ -26,22 +26,25 @@ Retrieve the download URL for a storage reference.
 
 The `useDownloadURL` hook takes the following parameters:
 
-- `reference`: (optional) `firebase.storage.Reference` that you would like the download URL for
+- `reference`: (optional) `storage.Reference` that you would like the download URL for
 
 Returns:
 
 - `downloadUrl`: A `string` download URL, or `undefined` if no storage reference is supplied
 - `loading`: A `boolean` to indicate whether the the download URL is still being loaded
-- `error`: Any `firebase.FirebaseError` returned by Firebase when trying to load the user, or `undefined` if there is no error
+- `error`: Any `storage.StorageError` returned by Firebase when trying to load the user, or `undefined` if there is no error
 
 #### Full example
 
 ```js
+import { ref, getStorage } from 'firebase/storage';
 import { useDownloadURL } from 'react-firebase-hooks/storage';
+
+const storage = getStorage(firebaseApp);
 
 const DownloadURL = () => {
   const [value, loading, error] = useDownloadURL(
-    firebase.storage().ref('path/to/file')
+    ref(storage, 'path/to/file')
   );
 
   return (

--- a/storage/index.js.flow
+++ b/storage/index.js.flow
@@ -1,8 +1,7 @@
 // @flow
-import typeof { FirebaseError } from 'firebase';
-import type { Reference } from 'firebase/storage';
+import type { Reference, StorageError } from 'firebase/storage';
 
-type LoadingHook<T> = [T | void, boolean, FirebaseError | void];
+type LoadingHook<T> = [T | void, boolean, StorageError | void];
 
 export type DownloadURLHook = LoadingHook<string>;
 declare export function useDownloadURL(ref?: Reference | null): DownloadURLHook;

--- a/storage/useDownloadURL.ts
+++ b/storage/useDownloadURL.ts
@@ -1,15 +1,17 @@
-import firebase from 'firebase/app';
+import {
+  getDownloadURL,
+  StorageError,
+  StorageReference,
+} from 'firebase/storage';
 import { useEffect } from 'react';
 import { LoadingHook, useComparatorRef, useLoadingValue } from '../util';
 
-export type DownloadURLHook = LoadingHook<string, firebase.FirebaseError>;
+export type DownloadURLHook = LoadingHook<string, StorageError>;
 
-export default (
-  storageRef?: firebase.storage.Reference | null
-): DownloadURLHook => {
+export default (storageRef?: StorageReference | null): DownloadURLHook => {
   const { error, loading, reset, setError, setValue, value } = useLoadingValue<
     string,
-    firebase.FirebaseError
+    StorageError
   >();
   const ref = useComparatorRef(storageRef, isEqual, reset);
 
@@ -18,15 +20,15 @@ export default (
       setValue(undefined);
       return;
     }
-    ref.current.getDownloadURL().then(setValue).catch(setError);
+    getDownloadURL(ref.current).then(setValue).catch(setError);
   }, [ref.current]);
 
   return [value, loading, error];
 };
 
 const isEqual = (
-  v1: firebase.storage.Reference | null | undefined,
-  v2: firebase.storage.Reference | null | undefined
+  v1: StorageReference | null | undefined,
+  v2: StorageReference | null | undefined
 ): boolean => {
   const bothNull: boolean = !v1 && !v2;
   const equal: boolean = !!v1 && !!v2 && v1.fullPath === v2.fullPath;

--- a/util/refHooks.ts
+++ b/util/refHooks.ts
@@ -40,10 +40,3 @@ export const useIsEqualRef = <T extends HasIsEqual<T>>(
 ): RefHook<T | null | undefined> => {
   return useComparatorRef(value, isEqual, onChange);
 };
-
-export const useIdentifyRef = <T>(
-  value: T | null | undefined,
-  onChange?: () => void
-): RefHook<T | null | undefined> => {
-  return useComparatorRef(value, (v1, v2) => v1 === v2, onChange);
-};

--- a/util/refHooks.ts
+++ b/util/refHooks.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-type RefHook<T> = {
+export type RefHook<T> = {
   current: T;
 };
 


### PR DESCRIPTION
Many people are waiting for https://github.com/CSFrequency/react-firebase-hooks/pull/153. As it is not merged but also doesn't contain a full migration of this package to firebase v9, I tried to migrate everything in one go.

This PR makes it possible to use `react-firebase-hooks` with Firebase v9 without using compatibility imports (`firebase/compat/...`).

This package migrates all components: auth, storage, firestore, database

This PR also already includes updates to the documentation.

This PR is published as [`react-firebase9-hooks`](https://www.npmjs.com/package/react-firebase9-hooks). The package will not be maintained after this PR is merged and `react-firebase-hooks@4` is released. The package only exists to test this PR.
It can be simply used in your project by updating the package.json to

```json
"dependencies": {
    "react-firebase-hooks": "npm:react-firebase9-hooks@4.0.0-alpha.0",
}
```

I currently run into type issues when using the new firestore methods, as `collection` and `get` of `firebase/firestore` are not generic yet. See e.g. https://github.com/firebase/firebase-js-sdk/blob/aa48accd54a406892ab972f1d904eab4189d4c64/packages/firestore/src/lite-api/reference.ts#L340-L344. This would need to be fixed in the firebase package.

# TODO

- [ ] Are the flow types correct? Did they ever work?
- [ ] Manually test all hooks


# Before merging the PR

- [ ] Revert changes to `name` and `version` in `package.json` and `package-lock.json`
- [ ] Remove disclaimer from `README`