### PR TITLE
Bugfix: in "snapshotToData" helper call snapshot.exists(). It was property, now it became method after v4 update (firebase v9)

### DIFF
--- a/firestore/helpers/index.ts
+++ b/firestore/helpers/index.ts
@@ -17,7 +17,7 @@ export const snapshotToData = <T = DocumentData>(
   refField?: string,
   transform?: (val: any) => T
 ) => {
-  if (!snapshot.exists) {
+  if (!snapshot.exists()) {
     return undefined;
   }
 


### PR DESCRIPTION
if was forgotten to call