### PR TITLE
Fix lacking type information for better type inference

### DIFF
--- a/firestore/useCollection.ts
+++ b/firestore/useCollection.ts
@@ -14,7 +14,7 @@ import {
 import { useIsEqualRef, useLoadingValue } from '../util';
 
 export const useCollection = <T = firebase.firestore.DocumentData>(
-  query?: firebase.firestore.Query | null,
+  query?: firebase.firestore.Query<T> | null,
   options?: Options
 ): CollectionHook<T> => {
   return useCollectionInternal<T>(true, query, options);
@@ -32,7 +32,7 @@ export const useCollectionData = <
   IDField extends string = '',
   RefField extends string = ''
 >(
-  query?: firebase.firestore.Query | null,
+  query?: firebase.firestore.Query<T> | null,
   options?: DataOptions<T> & InitialValueOptions<T[]>
 ): CollectionDataHook<T, IDField, RefField> => {
   return useCollectionDataInternal<T, IDField, RefField>(true, query, options);
@@ -43,7 +43,7 @@ export const useCollectionDataOnce = <
   IDField extends string = '',
   RefField extends string = ''
 >(
-  query?: firebase.firestore.Query | null,
+  query?: firebase.firestore.Query<T> | null,
   options?: OnceDataOptions<T> & InitialValueOptions<T[]>
 ): CollectionDataHook<T, IDField, RefField> => {
   return useCollectionDataInternal<T, IDField, RefField>(false, query, options);

--- a/firestore/useDocument.ts
+++ b/firestore/useDocument.ts
@@ -14,14 +14,14 @@ import {
 import { useIsEqualRef, useLoadingValue } from '../util';
 
 export const useDocument = <T = firebase.firestore.DocumentData>(
-  docRef?: firebase.firestore.DocumentReference | null,
+  docRef?: firebase.firestore.DocumentReference<T> | null,
   options?: Options
 ): DocumentHook<T> => {
   return useDocumentInternal<T>(true, docRef, options);
 };
 
 export const useDocumentOnce = <T = firebase.firestore.DocumentData>(
-  docRef?: firebase.firestore.DocumentReference | null,
+  docRef?: firebase.firestore.DocumentReference<T> | null,
   options?: OnceOptions
 ): DocumentHook<T> => {
   return useDocumentInternal<T>(false, docRef, options);
@@ -32,7 +32,7 @@ export const useDocumentData = <
   IDField extends string = '',
   RefField extends string = ''
 >(
-  docRef?: firebase.firestore.DocumentReference | null,
+  docRef?: firebase.firestore.DocumentReference<T> | null,
   options?: DataOptions<T> & InitialValueOptions<T>
 ): DocumentDataHook<T, IDField, RefField> => {
   return useDocumentDataInternal<T, IDField, RefField>(true, docRef, options);
@@ -43,7 +43,7 @@ export const useDocumentDataOnce = <
   IDField extends string = '',
   RefField extends string = ''
 >(
-  docRef?: firebase.firestore.DocumentReference | null,
+  docRef?: firebase.firestore.DocumentReference<T> | null,
   options?: OnceDataOptions<T> & InitialValueOptions<T>
 ): DocumentDataHook<T, IDField, RefField> => {
   return useDocumentDataInternal<T, IDField, RefField>(false, docRef, options);


### PR DESCRIPTION
Current type definition doesn't pass generic type T to the Query/DocumentReference.
This fixes type inference when used with FirestoreDataConverter