### PR TITLE
Fix HttpsCallable return type.

### DIFF
--- a/functions/useHttpsCallable.ts
+++ b/functions/useHttpsCallable.ts
@@ -6,7 +6,7 @@ import {
 import { useMemo, useState } from 'react';
 
 export type HttpsCallableHook<RequestData = unknown, ResponseData = unknown> = [
-  (data?: RequestData) => Promise<HttpsCallableResult<ResponseData> | unknown>,
+  (data?: RequestData) => Promise<HttpsCallableResult<ResponseData> | undefined>,
   boolean,
   Error | undefined
 ];


### PR DESCRIPTION
Considering the following line:

```typescript
const [submit] = useHttpsCallable<ContactFields, boolean>(functions, 'sendContact')
```

The return type for `submit` is `Promise<unknown>`. With this change, the return type is `Promise<HttpsCallableResult<boolean> | undefined>`