### PR TITLE
pr request  for useSendPasswordResetEmail hook + docs

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -646,7 +646,7 @@ The `useSendPasswordResetEmail` hook takes the following parameters:
 
 Returns:
 
-- `sendPasswordResetEmail(email: string)`: a function you can call to send a password reset emaail
+- `sendPasswordResetEmail(email: string, actionCodeSettings?:ActionCodeSettings)`: a function you can call to send a password reset email. Optionally accepts an [actionCodeSettings](https://firebase.google.com/docs/reference/js/auth.actioncodesettings.md#actioncodesettings_interface) object as well.
 - `sending`: A `boolean` to indicate whether the email is being sent
 - `error`: Any `Error` returned by Firebase when trying to send the email, or `undefined` if there is no error
 
@@ -660,6 +660,10 @@ const SendPasswordReset = () => {
   const [sendPasswordResetEmail, sending, error] = useSendPasswordResetEmail(
     auth
   );
+  
+  const actionCodeSettings = {
+  url: 'https://www.example.com/login'
+}
 
   if (error) {
     return (
@@ -680,7 +684,7 @@ const SendPasswordReset = () => {
       />
       <button
         onClick={async () => {
-          await sendPasswordResetEmail(email);
+          await sendPasswordResetEmail(email, actionCodeSettings);
           alert('Sent email');
         }}
       >

--- a/auth/useSendPasswordResetEmail.ts
+++ b/auth/useSendPasswordResetEmail.ts
@@ -1,12 +1,13 @@
 import {
   Auth,
   AuthError,
+  ActionCodeSettings,
   sendPasswordResetEmail as fbSendPasswordResetEmail,
 } from 'firebase/auth';
 import { useMemo, useState } from 'react';
 
 export type SendPasswordResetEmailHook = [
-  (email: string) => Promise<void>,
+  (email: string, actionCodeSettings?: ActionCodeSettings) => Promise<void>,
   boolean,
   AuthError | Error | undefined
 ];
@@ -15,11 +16,14 @@ export default (auth: Auth): SendPasswordResetEmailHook => {
   const [error, setError] = useState<AuthError>();
   const [loading, setLoading] = useState<boolean>(false);
 
-  const sendPasswordResetEmail = async (email: string) => {
+  const sendPasswordResetEmail = async (
+    email: string,
+    actionCodeSettings?: ActionCodeSettings
+  ) => {
     setLoading(true);
     setError(undefined);
     try {
-      await fbSendPasswordResetEmail(auth, email);
+      await fbSendPasswordResetEmail(auth, email, actionCodeSettings);
     } catch (err) {
       setError(err as AuthError);
     } finally {


### PR DESCRIPTION
`Add optional actionCodeSettings to useSendPasswordResetEmail.ts + documentation updated.`

_It's been a while since I've used TypeScript but I did check and make sure no warnings or errors popped up so please verify I didn't make any mistakes if you decide to merge! Thank you._

### Hi! I would like to propose a change to the `useSendPasswordResetEmail` hook.

Mainly, I want to be able to supply the optional `actionCodeSettings` object for the firebase `sendPasswordResetEmail` function: [firebase v9 documented here](https://firebase.google.com/docs/reference/js/auth.md#sendpasswordresetemail)

This way, I can supply the 'url' within the `actionCodeSettings` so when a user initiates password reset, they get the `"Continue"` button in the firebase dialog box after changing their password, and can be redirected to the page set in the url property: such as  `www.example.com/login`

Example:
```
// actionCodeSettings can set other properties as well, in the documentation linked. For my use case on web, URL is enough.

const actionCodeSettings = {
        url: "https://www.example.com/login",
      };

  const [sendPasswordResetEmail, sending, error] = useSendPasswordResetEmail(
    auth
  );
  
  // somewhere in the code we call sendPasswordResetEmail
  
    try {
      await sendPasswordResetEmail(email, actionCodeSettings);
    } 
  
```




