### PR TITLE
Fix useLoadingValue perf issue

### DIFF
--- a/util/useLoadingValue.ts
+++ b/util/useLoadingValue.ts
@@ -1,4 +1,4 @@
-import { useMemo, useReducer } from 'react';
+import { useCallback, useMemo, useReducer } from 'react';
 
 export type LoadingValue<T, E> = {
   error?: E;
@@ -60,18 +60,18 @@ export default <T, E>(getDefaultValue?: () => T): LoadingValue<T, E> => {
     defaultState(defaultValue)
   );
 
-  const reset = () => {
+  const reset = useCallback(() => {
     const defaultValue = getDefaultValue ? getDefaultValue() : undefined;
     dispatch({ type: 'reset', defaultValue });
-  };
+  }, [getDefaultValue]);
 
-  const setError = (error: E) => {
+  const setError = useCallback((error: E) => {
     dispatch({ type: 'error', error });
-  };
+  }, []);
 
-  const setValue = (value?: T) => {
+  const setValue = useCallback((value?: T) => {
     dispatch({ type: 'value', value });
-  };
+  }, []);
 
   return useMemo(
     () => ({


### PR DESCRIPTION
I'm using `useAuthState` in my application and found it causing my component re-render infinitely, after some debugging, I noticed the problem is in `useLoadingValue`, the returned `setValue` and `setError` are changing every time it re-run. (useMemo doesn't help here). We need to use `useCallback` to prevent them from changing.