### PR TITLE
feat: add id to useCollectionData and useCollectionDataOnce hooks

### DIFF
--- a/firestore/useCollection.ts
+++ b/firestore/useCollection.ts
@@ -146,10 +146,14 @@ const getValuesFromSnapshots = <T>(
   snapshots?: QuerySnapshot<T>,
   options?: SnapshotOptions
 ) => {
-  return useMemo(() => snapshots?.docs.map((doc) => doc.data(options)) as T[], [
-    snapshots,
-    options,
-  ]);
+  return useMemo(
+    () =>
+      snapshots?.docs.map((doc) => ({
+        ...doc.data(options),
+        id: doc.id,
+      })) as T[],
+    [snapshots, options]
+  );
 };
 
 const getDocsFnFromGetOptions = (


### PR DESCRIPTION
Would be useful to have the id in the useCollectionData and useCollectionDataOnce hooks, specially to filter among different  documents. Maybe it could also be one of the parametes if it must be included i'll do it.