### PR TITLE
Feature/initial value

### DIFF
--- a/firestore/README.md
+++ b/firestore/README.md
@@ -128,6 +128,7 @@ The `useCollectionData` hook takes the following parameters:
 - `options`: (optional) `Object` with the following parameters:
   - `snapshotListenOptions`: (optional) `firestore.SnapshotListenOptions` to customise how the collection is loaded
   - `snapshotOptions`: (optional) `firestore.SnapshotOptions` to customise how data is retrieved from snapshots
+  - `initialValue`: (optional) the initial value returned by the hook, until data from the firestore query has loaded
 
 Returns:
 
@@ -154,6 +155,7 @@ The `useCollectionDataOnce` hook takes the following parameters:
   - `getOptions`: (optional) `Object` to customise how the collection is loaded
     - `source`: (optional): `'default' | 'server' | 'cache'` Describes whether we should get from server or cache.
   - `snapshotOptions`: (optional) `firestore.SnapshotOptions` to customise how data is retrieved from snapshots
+  - `initialValue`: (optional) the initial value returned by the hook, until data from the firestore query has loaded
 
 Returns:
 
@@ -247,6 +249,7 @@ The `useDocumentData` hook takes the following parameters:
 - `options`: (optional) `Object` with the following parameters:
   - `snapshotListenOptions`: (optional) `firestore.SnapshotListenOptions` to customise how the collection is loaded
   - `snapshotOptions`: (optional) `firestore.SnapshotOptions` to customise how data is retrieved from snapshots
+  - `initialValue`: (optional) the initial value returned by the hook, until data from the firestore query has loaded
 
 Returns:
 
@@ -273,6 +276,7 @@ The `useDocumentDataOnce` hook takes the following parameters:
   - `getOptions`: (optional) `Object` to customise how the collection is loaded
     - `source`: (optional): `'default' | 'server' | 'cache'` Describes whether we should get from server or cach
   - `snapshotOptions`: (optional) `firestore.SnapshotOptions` to customise how data is retrieved from snapshots
+  - `initialValue`: (optional) the initial value returned by the hook, until data from the firestore query has loaded
 
 Returns:
 

--- a/firestore/types.ts
+++ b/firestore/types.ts
@@ -14,6 +14,9 @@ export type IDOptions<T> = {
 export type Options = {
   snapshotListenOptions?: SnapshotListenOptions;
 };
+export type InitialValueOptions<T> = {
+  initialValue?: T;
+};
 export type DataOptions<T> = Options & IDOptions<T>;
 export type OnceOptions = {
   getOptions?: GetOptions;

--- a/firestore/useDocument.ts
+++ b/firestore/useDocument.ts
@@ -18,6 +18,7 @@ import {
   DocumentHook,
   DocumentOnceHook,
   GetOptions,
+  InitialValueOptions,
   OnceDataOptions,
   OnceOptions,
   Options,
@@ -117,14 +118,16 @@ export const useDocumentOnce = <T = DocumentData>(
 
 export const useDocumentData = <T = DocumentData>(
   docRef?: DocumentReference<T> | null,
-  options?: DataOptions<T>
+  options?: DataOptions<T> & InitialValueOptions<T>
 ): DocumentDataHook<T> => {
   const snapshotOptions = options?.snapshotOptions;
   const [snapshot, loading, error] = useDocument<T>(docRef, options);
-  const value = useMemo(() => snapshot?.data(snapshotOptions) as T, [
-    snapshot,
-    snapshotOptions,
-  ]);
+
+  const initialValue = options?.initialValue;
+  const value = useMemo(
+    () => (snapshot?.data(snapshotOptions) ?? initialValue) as T | undefined,
+    [snapshot, snapshotOptions, initialValue]
+  );
 
   const resArray: DocumentDataHook<T> = [value, loading, error, snapshot];
   return useMemo(() => resArray, resArray);
@@ -132,17 +135,19 @@ export const useDocumentData = <T = DocumentData>(
 
 export const useDocumentDataOnce = <T = DocumentData>(
   docRef?: DocumentReference<T> | null,
-  options?: OnceDataOptions<T>
+  options?: OnceDataOptions<T> & InitialValueOptions<T>
 ): DocumentDataOnceHook<T> => {
   const snapshotOptions = options?.snapshotOptions;
   const [snapshot, loading, error, loadData] = useDocumentOnce<T>(
     docRef,
     options
   );
-  const value = useMemo(() => snapshot?.data(snapshotOptions) as T, [
-    snapshot,
-    snapshotOptions,
-  ]);
+
+  const initialValue = options?.initialValue;
+  const value = useMemo(
+    () => (snapshot?.data(snapshotOptions) ?? initialValue) as T | undefined,
+    [snapshot, snapshotOptions, initialValue]
+  );
 
   const resArray: DocumentDataOnceHook<T> = [
     value,


### PR DESCRIPTION
This is a PR related to #190 and #191.

It adds the possibility to define an initial value for the
- `useCollectionDataOnce`
- `useCollectionData`
- `useDocumentDataOnce`
- `useDocumentData`
hooks.

It is heavily based on PR #191 but as this PR was merged to the 3.0.x branch, it is not part of the current version (i.e. 5.0.x).

I've slightly changed the code compared to #191 and I also fixed some typing issues.

@chrisbianca, please let me know if I could somehow help in making this part of version 5 swiftly.

Thanks, Maurice