### PR TITLE
Fixed typo in README

### DIFF
--- a/firestore/README.md
+++ b/firestore/README.md
@@ -271,7 +271,7 @@ The `useDocumentDataOnce` hook takes the following parameters:
 - `reference`: (optional) `firestore.DocumentReference` for the data you would like to load
 - `options`: (optional) `Object` with the following parameters:
   - `getOptions`: (optional) `Object` to customise how the collection is loaded
-    - `source`: (optional): `'default' | 'server' | 'cache'` Describes whether we should get from server or cach
+    - `source`: (optional): `'default' | 'server' | 'cache'` Describes whether we should get from server or cache
   - `snapshotOptions`: (optional) `firestore.SnapshotOptions` to customise how data is retrieved from snapshots
 
 Returns:


### PR DESCRIPTION
There was a simple typo in the README. This change fixes it.