### PR TITLE
[auth] add useVerifyBeforeUpdateEmail hook

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -23,6 +23,7 @@ List of Auth hooks:
 - [useUpdateEmail](#useupdateemail)
 - [useUpdatePassword](#useupdatepassword)
 - [useUpdateProfile](#useupdateprofile)
+- [useVerifyBeforeUpdateEmail](#useverifybeforeupdateemail)
 - [useSendPasswordResetEmail](#usesendpasswordresetemail)
 - [useSendEmailVerification](#usesendemailverification)
 - [useSignOut](#usesignout)
@@ -469,7 +470,7 @@ The `useUpdateEmail` hook takes the following parameters:
 
 Returns:
 
-- `updateEmail(email: string)`: a function you can call to update the current user's email addres
+- `updateEmail(email: string)`: a function you can call to update the current user's email address
 - `updating`: A `boolean` to indicate whether the user update is processing
 - `error`: Any `Error` returned by Firebase when trying to update the user, or `undefined` if there is no error
 
@@ -626,6 +627,63 @@ const UpdateProfile = () => {
         }}
       >
         Update profile
+      </button>
+    </div>
+  );
+};
+```
+
+### useVerifyBeforeUpdateEmail
+
+```js
+const [verifyBeforeUpdateEmail, updating, error] = useVerifyBeforeUpdateEmail(auth);
+```
+
+Verify and update the current user's email address. Wraps the underlying `auth.verifyBeforeUpdateEmail` method and provides additional `updating` and `error` information.
+
+The `useVerifyBeforeUpdateEmail` hook takes the following parameters:
+
+- `auth`: `Auth` instance for the app you would like to monitor
+
+Returns:
+
+- `verifyBeforeUpdateEmail(email: string, actionCodeSettings: ActionCodeSettings | null)`: a function you can call to verify and update the current user's email address
+- `updating`: A `boolean` to indicate whether the user update is processing
+- `error`: Any `Error` returned by Firebase when trying to update the user, or `undefined` if there is no error
+
+#### Full Example
+
+```jsx
+import { useVerifyBeforeUpdateEmail } from 'react-firebase-hooks/auth';
+
+const UpdateEmail = () => {
+  const [email, setEmail] = useState('');
+  const [verifyBeforeUpdateEmail, updating, error] = useVerifyBeforeUpdateEmail(auth);
+
+  if (error) {
+    return (
+      <div>
+        <p>Error: {error.message}</p>
+      </div>
+    );
+  }
+  if (updating) {
+    return <p>Updating...</p>;
+  }
+  return (
+    <div className="App">
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <button
+        onClick={async () => {
+          await verifyBeforeUpdateEmail(email);
+          alert('Please check your email to verify your updated email address');
+        }}
+      >
+        Update email
       </button>
     </div>
   );

--- a/auth/index.ts
+++ b/auth/index.ts
@@ -24,9 +24,11 @@ export {
   useUpdateEmail,
   useUpdatePassword,
   useUpdateProfile,
+  useVerifyBeforeUpdateEmail,
   UpdateEmailHook,
   UpdatePasswordHook,
   UpdateProfileHook,
+  VerifyBeforeUpdateEmailHook,
 } from './useUpdateUser';
 
 export { EmailAndPasswordActionHook, SignInWithPopupHook } from './types';


### PR DESCRIPTION
First off, thanks for this library (@chrisbianca and @CSFrequency)!

I have some code that is using `useUpdateEmail()`, but I recently learned about the [verifyBeforeUpdateEmail](https://firebase.google.com/docs/reference/js/v8/firebase.User#verifybeforeupdateemail) function (which I would prefer to use instead of [updateEmail](https://firebase.google.com/docs/reference/js/v8/firebase.User#updateemail)).

I searched this repo, and did not see any feature requests or code related to `verifyBeforeUpdateEmail` so I went ahead and added it.

I didn't do any testing, but I followed all the `useUpdateEmail/updateEmail` code- everything is very similar.

Let me know if you would like any more info!

I also fixed 1 existing typo in the readme (`addres`->`address`).

