### PR TITLE
[auth] Fix import/export path on useIdToken

### DIFF
--- a/auth/index.ts
+++ b/auth/index.ts
@@ -40,3 +40,4 @@ export {
   useVerifyBeforeUpdateEmail,
   VerifyBeforeUpdateEmailHook,
 } from './useUpdateUser';
+export { default as useIdToken, IdTokenHook } from './useIdToken';

--- a/auth/useIdToken.ts
+++ b/auth/useIdToken.ts
@@ -1,6 +1,6 @@
 import { Auth, onIdTokenChanged, User } from 'firebase/auth';
 import { useEffect } from 'react';
-import { LoadingHook, useLoadingValue } from '../util/dist/util';
+import { LoadingHook, useLoadingValue } from '../util';
 
 export type IdTokenHook = LoadingHook<User | null, Error>;
 


### PR DESCRIPTION
There are some missing/incorrect paths on auth, it won't work as the [documentation](https://github.com/CSFrequency/react-firebase-hooks/tree/v5.1.x/auth#useidtoken) expects.

- Fix import path of `util` from dist to source
- Add export path of `auth/useIdToken.ts` into `auth/index.ts`