### PR TITLE
fix(snapshotToData): 'snapshot.exists()' is method, not property.

### DIFF
--- a/database/helpers/index.ts
+++ b/database/helpers/index.ts
@@ -15,7 +15,7 @@ export const snapshotToData = <T>(
   refField?: string,
   transform?: (val: any) => T
 ) => {
-  if (!snapshot.exists) {
+  if (!snapshot.exists()) {
     return undefined;
   }
 


### PR DESCRIPTION
`snapshot.exists()` should be called as a method.

This was previously fixed in v4 but has been reintroduced in v5.
Previous bugfix: https://github.com/CSFrequency/react-firebase-hooks/pull/179