### PR TITLE
[functions] useHttpsCallable now supports passing `HttpsCallableOptions` as a third parameter

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -27,6 +27,8 @@ The `useHttpsCallable` hook takes the following parameters:
 
 - `functions`: `functions.Functions` instance for your Firebase app
 - `name`: A `string` representing the name of the function to call
+- `options`: An optional `object` with the following properties:
+  - `timeout`: A `number` representing the timeout in milliseconds for the function call. Default is 70000 ms.
 
 Returns:
 

--- a/functions/useHttpsCallable.ts
+++ b/functions/useHttpsCallable.ts
@@ -2,6 +2,7 @@ import {
   Functions,
   httpsCallable,
   HttpsCallableResult,
+  HttpsCallableOptions,
 } from 'firebase/functions';
 import { useCallback, useState } from 'react';
 
@@ -20,7 +21,8 @@ export type HttpsCallableHook<
 
 export default <RequestData = unknown, ResponseData = unknown>(
   functions: Functions,
-  name: string
+  name: string,
+  options?: HttpsCallableOptions,
 ): HttpsCallableHook<RequestData, ResponseData> => {
   const [error, setError] = useState<Error>();
   const [loading, setLoading] = useState<boolean>(false);
@@ -31,7 +33,8 @@ export default <RequestData = unknown, ResponseData = unknown>(
     ): Promise<HttpsCallableResult<ResponseData> | undefined> => {
       const callable = httpsCallable<RequestData, ResponseData>(
         functions,
-        name
+        name,
+        options,
       );
       setLoading(true);
       setError(undefined);


### PR DESCRIPTION
When I created my fork I didn't notice https://github.com/CSFrequency/react-firebase-hooks/pull/296/files; 
However, I also updated README and it is forked from more up-to-date master so I decided to create PR anyway.

Thanks for the great library 🙂