### PR TITLE
Update README.md

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -22,6 +22,7 @@ List of Auth hooks:
 - [useSignInWithTwitter](#usesigninwithtwitter)
 - [useSignInWithYahoo](#usesigninwithyahoo)
 - [useSendSignInLinkToEmail](#usesendsigninlinktoemail)
+- [useSignInWithEmailLink](#usesigninwithemaillink)
 - [useUpdateEmail](#useupdateemail)
 - [useUpdatePassword](#useupdatepassword)
 - [useUpdateProfile](#useupdateprofile)


### PR DESCRIPTION
is it should display `useSignInWithEmailLink` hook in list?