### PR TITLE
[functions] Add options parameter to useHttpsCallable

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -27,6 +27,9 @@ The `useHttpsCallable` hook takes the following parameters:
 
 - `functions`: `functions.Functions` instance for your Firebase app
 - `name`: A `string` representing the name of the function to call
+- `options`: (optional) `Object` with the following parameters:
+  - `timeout`: (optional) `number` Time in milliseconds after which to cancel if there is no response
+  - `limitedUseAppCheckTokens`: (optional) `boolean` If set to true, uses limited-use App Check token for callable function requests from this instance of `Functions`
 
 Returns:
 

--- a/functions/useHttpsCallable.ts
+++ b/functions/useHttpsCallable.ts
@@ -1,6 +1,7 @@
 import {
   Functions,
   httpsCallable,
+  HttpsCallableOptions,
   HttpsCallableResult,
 } from 'firebase/functions';
 import { useCallback, useState } from 'react';
@@ -20,7 +21,8 @@ export type HttpsCallableHook<
 
 export default <RequestData = unknown, ResponseData = unknown>(
   functions: Functions,
-  name: string
+  name: string,
+  options?: HttpsCallableOptions,
 ): HttpsCallableHook<RequestData, ResponseData> => {
   const [error, setError] = useState<Error>();
   const [loading, setLoading] = useState<boolean>(false);
@@ -31,7 +33,8 @@ export default <RequestData = unknown, ResponseData = unknown>(
     ): Promise<HttpsCallableResult<ResponseData> | undefined> => {
       const callable = httpsCallable<RequestData, ResponseData>(
         functions,
-        name
+        name,
+        options,
       );
       setLoading(true);
       setError(undefined);
@@ -43,7 +46,7 @@ export default <RequestData = unknown, ResponseData = unknown>(
         setLoading(false);
       }
     },
-    [functions, name]
+    [functions, name, options]
   );
 
   return [callCallable, loading, error] as const;


### PR DESCRIPTION
According to the Firebase documentation, the [httpsCallable](https://firebase.google.com/docs/reference/node/firebase.functions.Functions#httpscallable) method also accepts a 3rd parameter (options).

- Updated `useHttpsCallable.ts`
- Updated `README.md` description